### PR TITLE
Add configuration options

### DIFF
--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -519,7 +519,7 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
     if (empty($caseId)) return '';
 
     $url = CRM_Utils_System::url('civicrm/contact/view/case', "reset=1&id={$caseId}&cid={$contactId}&action=view");
-    $html = "<a href='$url' class='action-item crm-hover-button no-popup' target='_blank'>Manage</a>";
+    $html = "<a href='$url' class='action-item crm-hover-button no-popup' target='_blank'>Manage (ID: {$caseId})</a>";
     return $html;
   }
   /**

--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -206,6 +206,9 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
     if (!empty($activity_type_id)) {
       $clauses[] = "activity.activity_type_id IN ( " . $activity_type_id . " ) ";
     }
+    $clauses[] = "activity.is_current_revision != 0";
+    $clauses[] = "activity.is_deleted = 0";
+
     if ($excludeCaseActivities) {
       $clauses[] = "case_activity.case_id IS NULL";
     }

--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -170,7 +170,7 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $select[] = 'COALESCE(target_contact_me.display_name, target_contact_random.display_name)   AS target_display_name';
       $groupBy[] = 'target_contact_me.display_name';
       $groupBy[] = 'target_contact_random.display_name';
-      $join[] = 'LEFT JOIN civicrm_activity_contact targets       ON (activity.id = targets.activity_id AND targets.record_type_id = 1)';
+      $join[] = 'LEFT JOIN civicrm_activity_contact targets       ON (activity.id = targets.activity_id AND targets.record_type_id = 3)';
       $join[] = 'LEFT JOIN civicrm_contact target_contact_random  ON (targets.contact_id = target_contact_random.id AND target_contact_random.is_deleted = 0)';
       $join[] = 'LEFT JOIN civicrm_contact target_contact_me      ON (targets.contact_id = target_contact_me.id AND target_contact_me.id = %1)';
     }

--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -522,7 +522,7 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
     if (empty($caseId)) return '';
 
     $url = CRM_Utils_System::url('civicrm/contact/view/case', "reset=1&id={$caseId}&cid={$contactId}&action=view");
-    $html = "<a href='$url' class='action-item crm-hover-button no-popup' target='_blank'>Case ID: {$caseId}</a>";
+    $html = "<a href='$url' class='action-item crm-hover-button no-popup' target='_blank'>Case {$caseId}</a>";
     return $html;
   }
   /**

--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -521,8 +521,33 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
   private static function formatCaseLink($contactId, $caseId) {
     if (empty($caseId)) return '';
 
+    $caseContacts = civicrm_api3('Case', 'getvalue', array(
+      'return' => "contact_id",
+      'id' => $caseId,
+    ));
+
+    foreach ($caseContacts as $caseContactId) {
+      if (!isset($firstCaseContactId)) {
+        $firstCaseContactId = $caseContactId;
+      }
+      if ($contactId == $caseContactId) {
+        $isClientOfCase = TRUE;
+        break;
+      }
+    }
+
+    if ($isClientOfCase) {
+      $label = "ID: {$caseId}";
+    }
+    else {
+      $contactName = civicrm_api3('Contact', 'getvalue', array(
+        'return' => "display_name",
+        'id' => $firstCaseContactId,
+      ));
+      $label = "ID: {$caseId}<br />({$contactName})";
+    }
     $url = CRM_Utils_System::url('civicrm/contact/view/case', "reset=1&id={$caseId}&cid={$contactId}&action=view");
-    $html = "<a href='$url' class='action-item crm-hover-button no-popup' target='_blank'>Case {$caseId}</a>";
+    $html = "<a href='$url' class='action-item crm-hover-button no-popup' target='_blank'>{$label}</a>";
     return $html;
   }
   /**

--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -522,7 +522,7 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
     if (empty($caseId)) return '';
 
     $url = CRM_Utils_System::url('civicrm/contact/view/case', "reset=1&id={$caseId}&cid={$contactId}&action=view");
-    $html = "<a href='$url' class='action-item crm-hover-button no-popup' target='_blank'>Manage (ID: {$caseId})</a>";
+    $html = "<a href='$url' class='action-item crm-hover-button no-popup' target='_blank'>Case ID: {$caseId}</a>";
     return $html;
   }
   /**

--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -659,6 +659,21 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
     }
 
+    if (
+      $activityTypeName &&
+      CRM_Case_BAO_Case::checkPermission($activityId, 'File On Case', $activityTypeId)
+    ) {
+      $actionLinks += array(
+        CRM_Core_Action::
+        ADD => array(
+          'name' => ts('File on Case'),
+          'url' => '#',
+          'extra' => 'onclick="javascript:fileOnCase( \'file\', ' . $activityId . ', null, this ); return false;"',
+          'title' => ts('File on Case'),
+        ),
+      );
+    }
+
     if (CRM_Core_Permission::check('delete activities')) {
       if ($showDelete) {
         $actionLinks += array(

--- a/CRM/Fastactivity/Form/Add.php
+++ b/CRM/Fastactivity/Form/Add.php
@@ -49,6 +49,10 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
    * form fields based on their requirement
    */
   public function setFields() {
+    // Remove print document activity type
+    $unwanted = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, "AND v.name = 'Print PDF Letter'");
+    $activityTypes = array_diff_key(CRM_Core_PseudoConstant::ActivityType(FALSE), $unwanted);
+
     $this->_fields = array(
       'subject' => array(
         'type' => 'text',
@@ -85,7 +89,7 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
         'label' => ts('Activity Type'),
         'required' => TRUE,
         'onchange' => "CRM.buildCustomData( 'Activity', this.value );",
-        'attributes' => array('' => '- ' . ts('select activity') . ' -') + CRM_Core_PseudoConstant::ActivityType(FALSE),
+        'attributes' => array('' => '- ' . ts('select activity') . ' -') + $activityTypes,
         'extra' => array('class' => 'crm-select2'),
       ),
       'priority_id' => array(
@@ -142,7 +146,7 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
       'followup_activity_type_id' => array(
         'type' => 'select',
         'label' => ts('Followup Activity'),
-        'attributes' => array('' => '- ' . ts('select activity') . ' -') + CRM_Core_PseudoConstant::ActivityType(FALSE),
+        'attributes' => array('' => '- ' . ts('select activity') . ' -') + $activityTypes,
         'extra' => array('class' => 'crm-select2'),
       ),
       // Add optional 'Subject' field for the Follow-up Activiity, CRM-4491
@@ -154,10 +158,6 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
         ),
       ),
     );
-
-    if ($printPDF = CRM_Utils_Array::key('Print PDF Letter', $this->_fields['followup_activity_type_id']['attributes'])) {
-      unset($this->_fields['followup_activity_type_id']['attributes'][$printPDF]);
-    }
   }
 
   public function preProcess()
@@ -352,20 +352,25 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
         $attribute = CRM_Utils_Array::value('attributes', $values);
         $required = !empty($values['required']);
         if ($values['type'] == 'wysiwyg') {
-          $element = $this->addWysiwyg($field, $values['label'], $attribute, $required);
+          $this->add('wysiwyg', $field, $values['label'], $attribute, $required);
         }
-        elseif ($values['type'] == 'select' && empty($attribute)) {
-          $element = $this->addSelect($field, array('entity' => 'activity'), $required);
+        elseif ($values['type'] == 'select') {
+          if ($field == 'activity_type_id' && ($this->_action == CRM_Core_Action::UPDATE)) {
+            // Don't allow changing activity type in edit mode
+            $this->add('hidden', $field, $values['label']);
+          }
+          elseif ($field == 'followup_activity_type_id') {
+            $this->addElement('select', $field, $values['label'], $attribute);
+          }
+          else {
+            $this->addSelect($field, $attribute, $required, CRM_Utils_Array::value('extra', $values));
+          }
         }
         elseif ($values['type'] == 'entityRef') {
-          $element = $this->addEntityRef($field, $values['label'], $attribute, $required);
+          $this->addEntityRef($field, $values['label'], $attribute, $required);
         }
         else {
-          $element = $this->add($values['type'], $field, $values['label'], $attribute, $required, CRM_Utils_Array::value('extra', $values));
-        }
-        if ($field == 'activity_type_id' && ($this->_action == CRM_Core_Action::UPDATE)) {
-          // Don't allow changing activity type in edit mode
-          $element->freeze();
+          $this->add($values['type'], $field, $values['label'], $attribute, $required, CRM_Utils_Array::value('extra', $values));
         }
       }
     }

--- a/CRM/Fastactivity/Form/Add.php
+++ b/CRM/Fastactivity/Form/Add.php
@@ -330,6 +330,8 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
   }
 
   public function buildQuickForm() {
+    $civiVersion = CRM_Core_BAO_Domain::version();
+
     if ($this->_cdType) {
       // AJAX query for custom data is called to civicrm/fastactivity/add
       // This handles that query and returns the edit form block for customData
@@ -352,7 +354,12 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
         $attribute = CRM_Utils_Array::value('attributes', $values);
         $required = !empty($values['required']);
         if ($values['type'] == 'wysiwyg') {
-          $this->add('wysiwyg', $field, $values['label'], $attribute, $required);
+          if (version_compare($civiVersion, '4.7', '<')) {
+            $this->addWysiwyg($field, $values['label'], $attribute, $required);
+          }
+          else {
+            $this->add('wysiwyg', $field, $values['label'], $attribute, $required);
+          }
         }
         elseif ($values['type'] == 'select') {
           if ($field == 'activity_type_id' && ($this->_action == CRM_Core_Action::UPDATE)) {

--- a/CRM/Fastactivity/Form/Add.php
+++ b/CRM/Fastactivity/Form/Add.php
@@ -149,7 +149,7 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
         'attributes' => array('' => '- ' . ts('select activity') . ' -') + $activityTypes,
         'extra' => array('class' => 'crm-select2'),
       ),
-      // Add optional 'Subject' field for the Follow-up Activiity, CRM-4491
+      // Add optional 'Subject' field for the Follow-up Activity, CRM-4491
       'followup_activity_subject' => array(
         'type' => 'text',
         'label' => ts('Subject'),
@@ -160,8 +160,7 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
     );
   }
 
-  public function preProcess()
-  {
+  public function preProcess() {
     // AJAX query for custom data is called to civicrm/fastactivity/add
     // This handles that query and returns the edit form block for customData
     $this->_cdType = CRM_Utils_Array::value('type', $_GET);
@@ -170,6 +169,8 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
       $this->assign('cdType', TRUE);
       return CRM_Custom_Form_CustomData::preProcess($this);
     }
+
+    CRM_Core_Form_RecurringEntity::preProcess('civicrm_activity');
 
     // Check if we should be accessing this page
     $allowedActions = array(CRM_Core_Action::ADD, CRM_Core_Action::UPDATE);

--- a/CRM/Fastactivity/Form/Add.php
+++ b/CRM/Fastactivity/Form/Add.php
@@ -370,6 +370,9 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
             $this->addElement('select', $field, $values['label'], $attribute);
           }
           else {
+            if (version_compare($civiVersion, '4.7', '<')) {
+              $attribute['entity'] = 'Activity';
+            }
             $this->addSelect($field, $attribute, $required, CRM_Utils_Array::value('extra', $values));
           }
         }

--- a/CRM/Fastactivity/Form/Add.php
+++ b/CRM/Fastactivity/Form/Add.php
@@ -370,8 +370,13 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
       }
     }
 
-    // Add campaign elements
-    self::buildFormElementsCampaign();
+    $config = CRM_Core_Config::singleton();
+    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
+    if ($campaignEnabled) {
+      // Add campaign elements
+      self::buildFormElementsCampaign();
+    }
+    $this->assign('campaignEnabled', $campaignEnabled);
 
     // this option should be available only during add mode
     if ($this->_action == CRM_Core_Action::ADD) {

--- a/CRM/Fastactivity/Form/Base.php
+++ b/CRM/Fastactivity/Form/Base.php
@@ -71,4 +71,13 @@ abstract class CRM_Fastactivity_Form_Base extends CRM_Core_Form {
     $this->assign('activityHeader', $header);
   }
 
+  /**
+   * Explicitly declare the entity api name.
+   *
+   * @return string
+   */
+  public function getDefaultEntity() {
+    return 'Activity';
+  }
+
 }

--- a/CRM/Fastactivity/Form/Settings.php
+++ b/CRM/Fastactivity/Form/Settings.php
@@ -1,0 +1,139 @@
+<?php
+/*--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
++--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
++--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +-------------------------------------------------------------------*/
+
+/**
+ * Form controller class
+ *
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/QuickForm+Reference
+ */
+class CRM_Fastactivity_Form_Settings extends CRM_Core_Form {
+
+  function buildQuickForm() {
+    parent::buildQuickForm();
+
+    CRM_Utils_System::setTitle(ts('Fast Activities - Settings'));
+
+    $settings = $this->getFormSettings();
+
+    foreach ($settings as $name => $setting) {
+      if (isset($setting['html_type'])) {
+        Switch ($setting['html_type']) {
+          case 'Text':
+              $this->addElement('text', $name, ts($setting['description']), $setting['html_attributes'], array());
+            break;
+          case 'Checkbox':
+            $this->addElement('checkbox', $name, ts($setting['description']), '', '');
+            break;
+        }
+      }
+    }
+    $this->addButtons(array(
+      array (
+        'type' => 'submit',
+        'name' => ts('Submit'),
+        'isDefault' => TRUE,
+      ),
+      array (
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      )
+    ));
+
+    // export form elements
+    $this->assign('elementNames', $this->getRenderableElementNames());
+
+  }
+
+  function postProcess() {
+    $changed = $this->_submitValues;
+    $settings = $this->getFormSettings(FALSE);
+    // Make sure we have all settings elements set (boolean settings will be unset by default and wouldn't be saved)
+    $settingsToSave = array_merge($settings, array_intersect_key($changed, $settings));
+    CRM_Fastactivity_Settings::save($settingsToSave);
+    parent::postProcess();
+    CRM_Core_Session::singleton()->setStatus('Configuration Updated', CRM_Fastactivity_Settings::TITLE, 'success');
+  }
+
+  /**
+   * Get the fields/elements defined in this form.
+   *
+   * @return array (string)
+   */
+  public function getRenderableElementNames() {
+    // The _elements list includes some items which should not be
+    // auto-rendered in the loop -- such as "qfKey" and "buttons".  These
+    // items don't have labels.  We'll identify renderable by filtering on
+    // the 'label'.
+    $elementNames = array();
+    foreach ($this->_elements as $element) {
+      /** @var HTML_QuickForm_Element $element */
+      $label = $element->getLabel();
+      if (!empty($label)) {
+        $elementNames[] = $element->getName();
+      }
+    }
+    return $elementNames;
+  }
+
+  /**
+   * Get the settings we are going to allow to be set on this form.
+   *
+   * @return array
+   */
+  function getFormSettings($metadata=TRUE) {
+    $unprefixedSettings = array();
+    $settings = civicrm_api3('setting', 'getfields', array('filters' => CRM_Fastactivity_Settings::getFilter()));
+    if (!empty($settings['values'])) {
+      foreach ($settings['values'] as $name => $values) {
+        if ($metadata) {
+          $unprefixedSettings[CRM_Fastactivity_Settings::getName($name, FALSE)] = $values;
+        }
+        else {
+          $unprefixedSettings[CRM_Fastactivity_Settings::getName($name, FALSE)] = NULL;
+        }
+      }
+    }
+    return $unprefixedSettings;
+  }
+
+  /**
+   * Set defaults for form.
+   *
+   * @see CRM_Core_Form::setDefaultValues()
+   */
+  function setDefaultValues() {
+    $settings = $this->getFormSettings(FALSE);
+    $defaults = array();
+
+    $existing = CRM_Fastactivity_Settings::get($settings);
+    if ($existing) {
+      foreach ($existing as $name => $value) {
+        $defaults[$name] = $value;
+      }
+    }
+    return $defaults;
+  }
+
+}

--- a/CRM/Fastactivity/Form/Settings.php
+++ b/CRM/Fastactivity/Form/Settings.php
@@ -127,7 +127,7 @@ class CRM_Fastactivity_Form_Settings extends CRM_Core_Form {
     $settings = $this->getFormSettings(FALSE);
     $defaults = array();
 
-    $existing = CRM_Fastactivity_Settings::get($settings);
+    $existing = CRM_Fastactivity_Settings::get(array_keys($settings));
     if ($existing) {
       foreach ($existing as $name => $value) {
         $defaults[$name] = $value;

--- a/CRM/Fastactivity/Form/Settings.php
+++ b/CRM/Fastactivity/Form/Settings.php
@@ -23,6 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +-------------------------------------------------------------------*/
 
+use CRM_Fastactivity_ExtensionUtil as E;
 /**
  * Form controller class
  *
@@ -33,22 +34,67 @@ class CRM_Fastactivity_Form_Settings extends CRM_Core_Form {
   function buildQuickForm() {
     parent::buildQuickForm();
 
-    CRM_Utils_System::setTitle(ts('Fast Activities - Settings'));
+    $className = E::CLASS_PREFIX . '_Settings';
+    CRM_Utils_System::setTitle($className::TITLE . ' - ' . E::ts('Settings'));
+
+    $className = E::CLASS_PREFIX . '_Form_SettingsCustom';
+    if (method_exists($className, 'buildQuickFormPre')) {
+      $className::buildQuickFormPre($this);
+    }
 
     $settings = $this->getFormSettings();
 
     foreach ($settings as $name => $setting) {
       if (isset($setting['html_type'])) {
-        Switch ($setting['html_type']) {
-          case 'Text':
-              $this->addElement('text', $name, ts($setting['description']), $setting['html_attributes'], array());
+        Switch (strtolower($setting['html_type'])) {
+          case 'text':
+            $this->addElement('text', $name, ts($setting['description']), $setting['html_attributes'], array());
             break;
-          case 'Checkbox':
+          case 'checkbox':
             $this->addElement('checkbox', $name, ts($setting['description']), '', '');
             break;
+          case 'datepicker':
+            foreach ($setting['html_extra'] as $key => $value) {
+              if ($key == 'minDate') {
+                $minDate = new DateTime('now');
+                $minDate->modify($value);
+                $setting['html_extra'][$key] = $minDate->format('Y-m-d');
+              }
+            }
+            $this->add('datepicker', $name, ts($setting['description']), $setting['html_attributes'], FALSE, $setting['html_extra']);
+            break;
+          case 'select2':
+            $className = E::CLASS_PREFIX . '_Form_SettingsCustom';
+            if (method_exists($className, 'addSelect2Element')) {
+              $className::addSelect2Element($this, $name, $setting);
+            }
+            break;
+          case 'select':
+            $className = E::CLASS_PREFIX . '_Form_SettingsCustom';
+            if (method_exists($className, 'addSelectElement')) {
+              $className::addSelectElement($this, $name, $setting);
+            }
+            break;
+          case 'hidden':
+            $hidden = TRUE;
+        }
+
+        if (isset($hidden)) {
+          continue;
+        }
+
+        $adminGroup = isset($setting['admin_group']) ? $setting['admin_group'] : 'default';
+        $elementGroups[$adminGroup]['elementNames'][] = $name;
+        // Title and description may not be defined on all elements (they only need to be on one)
+        if (!empty($setting['admin_grouptitle'])) {
+          $elementGroups[$setting['admin_group']]['title'] = $setting['admin_grouptitle'];
+        }
+        if (!empty($setting['admin_groupdescription'])) {
+          $elementGroups[$setting['admin_group']]['description'] = $setting['admin_groupdescription'];
         }
       }
     }
+
     $this->addButtons(array(
       array (
         'type' => 'submit',
@@ -62,39 +108,27 @@ class CRM_Fastactivity_Form_Settings extends CRM_Core_Form {
     ));
 
     // export form elements
-    $this->assign('elementNames', $this->getRenderableElementNames());
+    $this->assign('elementGroups', $elementGroups);
 
   }
 
   function postProcess() {
+    $className = E::CLASS_PREFIX . '_Settings';
     $changed = $this->_submitValues;
-    $settings = $this->getFormSettings(FALSE);
-    // Make sure we have all settings elements set (boolean settings will be unset by default and wouldn't be saved)
-    $settingsToSave = array_merge($settings, array_intersect_key($changed, $settings));
-    CRM_Fastactivity_Settings::save($settingsToSave);
-    parent::postProcess();
-    CRM_Core_Session::singleton()->setStatus('Configuration Updated', CRM_Fastactivity_Settings::TITLE, 'success');
-  }
-
-  /**
-   * Get the fields/elements defined in this form.
-   *
-   * @return array (string)
-   */
-  public function getRenderableElementNames() {
-    // The _elements list includes some items which should not be
-    // auto-rendered in the loop -- such as "qfKey" and "buttons".  These
-    // items don't have labels.  We'll identify renderable by filtering on
-    // the 'label'.
-    $elementNames = array();
-    foreach ($this->_elements as $element) {
-      /** @var HTML_QuickForm_Element $element */
-      $label = $element->getLabel();
-      if (!empty($label)) {
-        $elementNames[] = $element->getName();
+    $settings = $this->getFormSettings(TRUE);
+    foreach ($settings as &$setting) {
+      if ($setting['html_type'] == 'Checkbox') {
+        $setting = false;
+      }
+      else {
+        $setting = NULL;
       }
     }
-    return $elementNames;
+    // Make sure we have all settings elements set (boolean settings will be unset by default and wouldn't be saved)
+    $settingsToSave = array_merge($settings, array_intersect_key($changed, $settings));
+    $className::save($settingsToSave);
+    parent::postProcess();
+    CRM_Core_Session::singleton()->setStatus('Configuration Updated', $className::TITLE, 'success');
   }
 
   /**
@@ -103,15 +137,16 @@ class CRM_Fastactivity_Form_Settings extends CRM_Core_Form {
    * @return array
    */
   function getFormSettings($metadata=TRUE) {
+    $className = E::CLASS_PREFIX . '_Settings';
     $unprefixedSettings = array();
-    $settings = civicrm_api3('setting', 'getfields', array('filters' => CRM_Fastactivity_Settings::getFilter()));
+    $settings = civicrm_api3('setting', 'getfields', array('filters' => $className::getFilter()));
     if (!empty($settings['values'])) {
       foreach ($settings['values'] as $name => $values) {
         if ($metadata) {
-          $unprefixedSettings[CRM_Fastactivity_Settings::getName($name, FALSE)] = $values;
+          $unprefixedSettings[$className::getName($name, FALSE)] = $values;
         }
         else {
-          $unprefixedSettings[CRM_Fastactivity_Settings::getName($name, FALSE)] = NULL;
+          $unprefixedSettings[$className::getName($name, FALSE)] = NULL;
         }
       }
     }
@@ -124,10 +159,11 @@ class CRM_Fastactivity_Form_Settings extends CRM_Core_Form {
    * @see CRM_Core_Form::setDefaultValues()
    */
   function setDefaultValues() {
+    $className = E::CLASS_PREFIX . '_Settings';
     $settings = $this->getFormSettings(FALSE);
     $defaults = array();
 
-    $existing = CRM_Fastactivity_Settings::get(array_keys($settings));
+    $existing = $className::get(array_keys($settings));
     if ($existing) {
       foreach ($existing as $name => $value) {
         $defaults[$name] = $value;

--- a/CRM/Fastactivity/Form/View.php
+++ b/CRM/Fastactivity/Form/View.php
@@ -80,8 +80,8 @@ class CRM_Fastactivity_Form_View extends CRM_Fastactivity_Form_Base {
 
     // Get activity record
     $activityRecord = civicrm_api3('Activity', 'getsingle', array(
-      'sequential' => 1,
       'id' => $this->_activityId,
+      'return' => ["case_id", "status_id", "activity_date_time", "activity_type_id", "subject", "details", "priority_id", "duration", "medium_id", "campaign_id", "engagement_level"],
     ));
 
     // Get Activity Status
@@ -102,6 +102,17 @@ class CRM_Fastactivity_Form_View extends CRM_Fastactivity_Form_Base {
     // Get activity subject
     $this->_activitySubject = isset($activityRecord['subject']) ? $activityRecord['subject'] : NULL;
     $activityDetails['subject'] = $this->_activitySubject;
+
+    // Case ID
+    if (isset($activityRecord['case_id'])) {
+      $caseDetail = civicrm_api3('Case', 'getsingle', array(
+        'id' => CRM_Utils_Array::first($activityRecord['case_id']),
+        'return' => ["subject", "case_type_id"],
+      ));
+      $activityDetails['case_id'] = CRM_Utils_Array::first($activityRecord['case_id']);
+      $activityDetails['case_type'] = CRM_Core_PseudoConstant::getLabel('CRM_Case_BAO_Case', 'case_type_id', $caseDetail['case_type_id']);
+      $activityDetails['case_subject'] = $caseDetail['subject'];
+    }
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       // Don't need to load any more info about the activity

--- a/CRM/Fastactivity/Form/View.php
+++ b/CRM/Fastactivity/Form/View.php
@@ -100,7 +100,7 @@ class CRM_Fastactivity_Form_View extends CRM_Fastactivity_Form_Base {
       $activityDetails['typeDescription'] = $activityTypeDescription;
     }
     // Get activity subject
-    $this->_activitySubject = isset($activityRecord['subject']) ? $activityRecord['subject'] : null;
+    $this->_activitySubject = isset($activityRecord['subject']) ? $activityRecord['subject'] : NULL;
     $activityDetails['subject'] = $this->_activitySubject;
 
     if ($this->_action & CRM_Core_Action::DELETE) {
@@ -111,7 +111,7 @@ class CRM_Fastactivity_Form_View extends CRM_Fastactivity_Form_Base {
     }
     else {
       $priorities = CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'priority_id');
-      $activityDetails['details'] = isset($activityRecord['details']) ? $activityRecord['details'] : null;
+      $activityDetails['details'] = isset($activityRecord['details']) ? $activityRecord['details'] : NULL;
 
       $this->_activitySourceContacts = self::getSourceContacts($this->_activityId);
       $this->_activityAssigneeContacts = self::getAssigneeContacts($this->_activityId);
@@ -121,7 +121,8 @@ class CRM_Fastactivity_Form_View extends CRM_Fastactivity_Form_Base {
       $activityDetails['assigneeContacts'] = $this->_activityAssigneeContacts;
       $activityDetails['targetContacts'] = $this->_activityTargetContacts;
 
-      $activityDetails['priority'] = isset($activityRecord['priority_id']) ? $priorities[$activityRecord['priority_id']] : null;
+      $activityDetails['priority'] = isset($activityRecord['priority_id']) ? $priorities[$activityRecord['priority_id']] : NULL;
+      $activityDetails['duration'] = isset($activityRecord['duration']) ? $activityRecord['duration'] : NULL;
 
       if (isset($activityRecord['medium_id'])) {
         $activityLabels = CRM_Fastactivity_BAO_Activity::getActivityLabels('encounter_medium');

--- a/CRM/Fastactivity/Form/View.php
+++ b/CRM/Fastactivity/Form/View.php
@@ -128,8 +128,13 @@ class CRM_Fastactivity_Form_View extends CRM_Fastactivity_Form_Base {
         $activityDetails['medium'] = $activityLabels[$activityRecord['medium_id']];
       }
 
-      // Add campaign details
-      $activityDetails = self::addCampaignDetails($activityRecord, $activityDetails);
+      $config = CRM_Core_Config::singleton();
+      $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
+      if ($campaignEnabled) {
+        // Add campaign details
+        $activityDetails = self::addCampaignDetails($activityRecord, $activityDetails);
+      }
+      $this->assign('campaignEnabled', $campaignEnabled);
 
       $this->assign('customDataType', 'Activity');
       $this->assign('customDataSubType', $this->_activityTypeId);

--- a/CRM/Fastactivity/Page/AJAX.php
+++ b/CRM/Fastactivity/Page/AJAX.php
@@ -31,6 +31,7 @@ class CRM_Fastactivity_Page_AJAX {
     // Load settings
     $params['optionalCols']['campaign_title'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_campaign_title');
     $params['optionalCols']['duration'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_duration');
+    $params['optionalCols']['case'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_case');
     $params['optionalCols']['target_contact'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_target_contact');
     $params['excludeCaseActivities'] = (bool) CRM_Fastactivity_Settings::getValue('tab_exclude_case_activities');
 
@@ -49,6 +50,9 @@ class CRM_Fastactivity_Page_AJAX {
     $sortMapper[] = 'status_id';
     if ($params['optionalCols']['duration']) {
       $sortMapper[] = 'activity_duration';
+    }
+    if ($params['optionalCols']['case']) {
+      $sortMapper[] = 'activity_case_id';
     }
 
     $sEcho = CRM_Utils_Type::escape($_REQUEST['sEcho'], 'Integer');
@@ -127,6 +131,9 @@ class CRM_Fastactivity_Page_AJAX {
     $selectorElements[] = 'status';
     if ($params['optionalCols']['duration']) {
       $selectorElements[] = 'duration';
+    }
+    if ($params['optionalCols']['case']) {
+      $selectorElements[] = 'activity_case_id';
     }
     $selectorElements[] = 'links';
     $selectorElements[] = 'class';

--- a/CRM/Fastactivity/Page/AJAX.php
+++ b/CRM/Fastactivity/Page/AJAX.php
@@ -47,7 +47,7 @@ class CRM_Fastactivity_Page_AJAX {
     }
     $sortMapper[] = 'assignee_display_name';
     $sortMapper[] = 'activity_date_time';
-    $sortMapper[] = 'status_id';
+    $sortMapper[] = 'activity.status_id';
     if ($params['optionalCols']['duration']) {
       $sortMapper[] = 'activity_duration';
     }

--- a/CRM/Fastactivity/Page/AJAX.php
+++ b/CRM/Fastactivity/Page/AJAX.php
@@ -26,17 +26,30 @@ class CRM_Fastactivity_Page_AJAX {
     $contactID = CRM_Utils_Type::escape($_POST['contact_id'], 'Integer');
     $context = CRM_Utils_Type::escape(CRM_Utils_Array::value('context', $_GET), 'String');
 
+    $params = $_POST;
+
+    // Load settings
+    $params['optionalCols']['campaign_title'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_campaign_title');
+    $params['optionalCols']['duration'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_duration');
+    $params['optionalCols']['target_contact'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_target_contact');
+    $params['excludeCaseActivities'] = (bool) CRM_Fastactivity_Settings::getValue('tab_exclude_case_activities');
+
     // Map column Id to the actual SQL query result column we are going to order by
-    $sortMapper = array(
-      0 => 'activity_type_id',
-      1 => 'activity_subject',
-      2 => 'activity_campaign_title',
-      3 => 'source_display_name',
-      // 4 => 'target_display_name', we are not showing target contact column
-      4 => 'assignee_display_name',
-      5 => 'activity_date_time',
-      6 => 'status_id',
-    );
+    $sortMapper[] = 'activity_type_id';
+    $sortMapper[] = 'activity_subject';
+    if ($params['optionalCols']['campaign_title']) {
+      $sortMapper[] = 'activity_campaign_title';
+    }
+    $sortMapper[] = 'source_display_name';
+    if ($params['optionalCols']['target_contact']) {
+      $sortMapper[] = 'target_display_name';
+    }
+    $sortMapper[] = 'assignee_display_name';
+    $sortMapper[] = 'activity_date_time';
+    $sortMapper[] = 'status_id';
+    if ($params['optionalCols']['duration']) {
+      $sortMapper[] = 'activity_duration';
+    }
 
     $sEcho = CRM_Utils_Type::escape($_REQUEST['sEcho'], 'Integer');
     $offset = isset($_REQUEST['iDisplayStart']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayStart'], 'Integer') : 0;
@@ -44,7 +57,6 @@ class CRM_Fastactivity_Page_AJAX {
     $sort = isset($_REQUEST['iSortCol_0']) ? CRM_Utils_Array::value(CRM_Utils_Type::escape($_REQUEST['iSortCol_0'], 'Integer'), $sortMapper) : NULL;
     $sortOrder = isset($_REQUEST['sSortDir_0']) ? CRM_Utils_Type::escape($_REQUEST['sSortDir_0'], 'MysqlOrderByDirection') : 'asc';
 
-    $params = $_POST;
     if ($sort && $sortOrder) {
       $params['sortBy'] = $sort . ' ' . $sortOrder;
     }
@@ -85,18 +97,39 @@ class CRM_Fastactivity_Page_AJAX {
     }
 
     $iFilteredTotal = $iTotal = $params['total'];
-    $selectorElements = array(
-      'activity_type',
-      'subject',
-      'campaign',
-      'source_contact',
-      // 'target_contact', we are not showing target contact column
-      'assignee_contact',
-      'activity_date',
-      'status',
-      'links',
-      'class',
-    );
+    $sortMapper[] = 'activity_type_id';
+    $sortMapper[] = 'activity_subject';
+    if ($params['optionalCols']['campaign_title']) {
+      $sortMapper[] = 'activity_campaign_title';
+    }
+    $sortMapper[] = 'source_display_name';
+    if ($params['optionalCols']['target_contact']) {
+      $sortMapper[] = 'target_display_name';
+    }
+    $sortMapper[] = 'assignee_display_name';
+    $sortMapper[] = 'activity_date_time';
+    $sortMapper[] = 'status_id';
+    if ($params['optionalCols']['duration']) {
+      $sortMapper[] = 'duration';
+    }
+
+    $selectorElements[] = 'activity_type';
+    $selectorElements[] = 'subject';
+    if ($params['optionalCols']['campaign_title']) {
+      $selectorElements[] = 'campaign';
+    }
+    $selectorElements[] = 'source_contact';
+    if ($params['optionalCols']['target_contact']) {
+      $selectorElements[] = 'target_contact';
+    }
+    $selectorElements[] = 'assignee_contact';
+    $selectorElements[] = 'activity_date';
+    $selectorElements[] = 'status';
+    if ($params['optionalCols']['duration']) {
+      $selectorElements[] = 'duration';
+    }
+    $selectorElements[] = 'links';
+    $selectorElements[] = 'class';
 
     header('Content-Type: application/json');
     echo CRM_Utils_JSON::encodeDataTableSelector($activities, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);

--- a/CRM/Fastactivity/Page/AJAX.php
+++ b/CRM/Fastactivity/Page/AJAX.php
@@ -67,24 +67,8 @@ class CRM_Fastactivity_Page_AJAX {
     }
 
     // store the activity filter preference CRM-11761
-    $session = CRM_Core_Session::singleton();
-    $userID = $session->get('userID');
+    $userID = CRM_Core_Session::getLoggedInContactID();
     if ($userID) {
-      //flush cache before setting filter to account for global cache (memcache)
-      $domainID = CRM_Core_Config::domainID();
-      $cacheKey = CRM_Core_BAO_Setting::inCache(
-        CRM_Core_BAO_Setting::PERSONAL_PREFERENCES_NAME,
-        'activity_tab_filter',
-        NULL,
-        $userID,
-        TRUE,
-        $domainID,
-        TRUE
-      );
-      if ($cacheKey) {
-        CRM_Core_BAO_Setting::flushCache($cacheKey);
-      }
-
       $activityFilter = array(
         'activity_type_id' => empty($params['activity_type_id']) ? '' : CRM_Utils_Type::escape($params['activity_type_id'], 'String'),
         'activity_type_exclude_filter_id' => empty($params['activity_type_exclude_id']) ? '' : CRM_Utils_Type::escape($params['activity_type_exclude_id'], 'String'),

--- a/CRM/Fastactivity/Page/Tab.php
+++ b/CRM/Fastactivity/Page/Tab.php
@@ -31,6 +31,12 @@ class CRM_Fastactivity_Page_Tab extends CRM_Core_Page {
     $this->assign('admin', FALSE);
     $this->assign('context', 'activity');
 
+    // Load settings
+    $params['optionalCols']['campaign_title'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_campaign_title');
+    $params['optionalCols']['duration'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_duration');
+    $params['optionalCols']['target_contact'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_target_contact');
+    $this->assign('optionalCols', $params['optionalCols']);
+
     // Create controller for the activity filter
     // This is a multi-select dropdown which allows to filter on multiple activity types
     $controller = new CRM_Core_Controller_Simple(

--- a/CRM/Fastactivity/Page/Tab.php
+++ b/CRM/Fastactivity/Page/Tab.php
@@ -34,6 +34,7 @@ class CRM_Fastactivity_Page_Tab extends CRM_Core_Page {
     // Load settings
     $params['optionalCols']['campaign_title'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_campaign_title');
     $params['optionalCols']['duration'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_duration');
+    $params['optionalCols']['case'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_case');
     $params['optionalCols']['target_contact'] = (bool) CRM_Fastactivity_Settings::getValue('tab_col_target_contact');
     $this->assign('optionalCols', $params['optionalCols']);
 

--- a/CRM/Fastactivity/Settings.php
+++ b/CRM/Fastactivity/Settings.php
@@ -1,0 +1,83 @@
+<?php
+
+class CRM_Fastactivity_Settings {
+
+  CONST TITLE = 'FastActivity';
+
+  /**
+   * Get settings prefix name for this extension
+   * @return string
+   */
+  public static function getPrefix() {
+    return 'fastactivity_';
+  }
+
+  /**
+   * Get filter of valid settings for this extension
+   * @return array
+   */
+  public static function getFilter() {
+    return array('group' => 'fastactivity');
+  }
+
+  /**
+   * Get name of setting
+   * @param: setting name
+   * @prefix: Boolean
+   */
+  public static function getName($name, $prefix = false) {
+    $ret = str_replace(self::getPrefix(),'',$name);
+    if ($prefix) {
+      $ret = self::getPrefix().$ret;
+    }
+    return $ret;
+  }
+
+  /**
+   * Save settings. Accepts an array of name=>value pairs.  Name can be with or without prefix (it will be added if missing).
+   * @param array $values Array of settings and values with or without prefix (eg. array(fastactivity_username => 'test')) to save
+   */
+  public static function save($settings) {
+    foreach ($settings as $name => $value) {
+      $prefixedSettings[self::getName($name, TRUE)] = $value;
+    }
+    civicrm_api3('setting', 'create', $prefixedSettings);
+  }
+
+  /**
+   * Read setting that has prefix in database and return single value
+   * @param $name
+   * @return mixed
+   */
+  public static function getValue($name) {
+    $settings = civicrm_api3('setting', 'get', array('return' => CRM_Fastactivity_Settings::getName($name,true)));
+    $domainID = CRM_Core_Config::domainID();
+    if (isset($settings['values'][$domainID][CRM_Fastactivity_Settings::getName($name,true)])) {
+      return $settings['values'][$domainID][CRM_Fastactivity_Settings::getName($name, true)];
+    }
+    return '';
+  }
+
+  /**
+   * Get settings
+   * @param array $settings of settings (eg. array(username, password))
+   *
+   * @return array
+   */
+  public static function get($settings) {
+    $domainID = CRM_Core_Config::domainID();
+
+    foreach ($settings as $name => $value) {
+      $prefixedSettings[self::getName($name, TRUE)] = $value;
+    }
+    $settingsResult = civicrm_api3('setting', 'get', array('return' => array_keys($prefixedSettings)));
+    if (isset($settingsResult['values'][$domainID])) {
+      foreach ($settingsResult['values'][$domainID] as $name => $value) {
+        $unprefixedSettings[self::getName($name)] = $value;
+      }
+      return empty($unprefixedSettings) ? NULL : $unprefixedSettings;
+    }
+    return array();
+  }
+
+}

--- a/CRM/Fastactivity/Settings.php
+++ b/CRM/Fastactivity/Settings.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Fastactivity_ExtensionUtil as E;
+
 class CRM_Fastactivity_Settings {
 
   CONST TITLE = 'FastActivity';
@@ -24,6 +26,7 @@ class CRM_Fastactivity_Settings {
    * Get name of setting
    * @param: setting name
    * @prefix: Boolean
+   * @return: string
    */
   public static function getName($name, $prefix = false) {
     $ret = str_replace(self::getPrefix(),'',$name);
@@ -35,7 +38,7 @@ class CRM_Fastactivity_Settings {
 
   /**
    * Save settings. Accepts an array of name=>value pairs.  Name can be with or without prefix (it will be added if missing).
-   * @param array $values Array of settings and values with or without prefix (eg. array(fastactivity_username => 'test')) to save
+   * @param array $values Array of settings and values with or without prefix (eg. array(smartdebit_username => 'test')) to save
    */
   public static function save($settings) {
     foreach ($settings as $name => $value) {
@@ -50,10 +53,11 @@ class CRM_Fastactivity_Settings {
    * @return mixed
    */
   public static function getValue($name) {
-    $settings = civicrm_api3('setting', 'get', array('return' => CRM_Fastactivity_Settings::getName($name,true)));
+    $className = E::CLASS_PREFIX . '_Settings';
+    $settings = civicrm_api3('setting', 'get', array('return' => $className::getName($name,true)));
     $domainID = CRM_Core_Config::domainID();
-    if (isset($settings['values'][$domainID][CRM_Fastactivity_Settings::getName($name,true)])) {
-      return $settings['values'][$domainID][CRM_Fastactivity_Settings::getName($name, true)];
+    if (isset($settings['values'][$domainID][$className::getName($name,true)])) {
+      return $settings['values'][$domainID][$className::getName($name, true)];
     }
     return '';
   }
@@ -65,6 +69,10 @@ class CRM_Fastactivity_Settings {
    * @return array
    */
   public static function get($settings) {
+    if ((!is_array($settings) || empty($settings))) {
+      return array();
+    }
+
     $domainID = CRM_Core_Config::domainID();
 
     foreach ($settings as $name) {

--- a/CRM/Fastactivity/Settings.php
+++ b/CRM/Fastactivity/Settings.php
@@ -67,10 +67,10 @@ class CRM_Fastactivity_Settings {
   public static function get($settings) {
     $domainID = CRM_Core_Config::domainID();
 
-    foreach ($settings as $name => $value) {
-      $prefixedSettings[self::getName($name, TRUE)] = $value;
+    foreach ($settings as $name) {
+      $prefixedSettings[] = self::getName($name, TRUE);
     }
-    $settingsResult = civicrm_api3('setting', 'get', array('return' => array_keys($prefixedSettings)));
+    $settingsResult = civicrm_api3('setting', 'get', array('return' => $prefixedSettings));
     if (isset($settingsResult['values'][$domainID])) {
       foreach ($settingsResult['values'][$domainID] as $name => $value) {
         $unprefixedSettings[self::getName($name)] = $value;

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ CiviCRM Extension for high performance activity features
 Currently this extension implements a "FastActivity" tab which uses an entirely new BAO class (CRM_Fastactivity_BAO_Activity) to query the database.
 This is implemented in the "standard" CiviCRM format with a separate whereClause function which is not present in the original CRM_Activity_BAO_Activity class.  This should allow for easy implementation of extended filtering in the future.
 
+## Configuration
+Settings such as which columns to display can be configured under __Administer->Customize Data and Screens->Fast Activities Tab__
+
 ## Features
 - A new filter is provided on the contact activities tab which uses a multi-select to allow filtering on multiple activity types.
 - An add/remove filter is added on edit activity for "With Contact" when > 20 to allow editing this field on large records.
 - A new filter is provided on the contact activities tab which uses a multi-select to allow filtering on campaigns and their sub-campaigns.
-
-## Not implemented
-- The activity search functions are not in the scope of this extension.
+- Some columns can be shown/hidden by configuring settings.
+- Case activities can optionally be shown.
 
 ## Requirements
 - Requires campaign extension (for campaigntree API) to search for activities of child campaigns in contact activity tab.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ CiviCRM Extension for high performance activity features
 Currently this extension implements a "FastActivity" tab which uses an entirely new BAO class (CRM_Fastactivity_BAO_Activity) to query the database.
 This is implemented in the "standard" CiviCRM format with a separate whereClause function which is not present in the original CRM_Activity_BAO_Activity class.  This should allow for easy implementation of extended filtering in the future.
 
+## Installation
+For Release 1.4 and above (which includes a link to "File on Case" for activities) you need to apply https://github.com/civicrm/civicrm-core/pull/12620 to CiviCRM core if you are using a release earlier than 5.6.
+ 
 ## Configuration
 Settings such as which columns to display can be configured under __Administer->Customize Data and Screens->Fast Activities Tab__
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ Settings such as which columns to display can be configured under __Administer->
 - A new filter is provided on the contact activities tab which uses a multi-select to allow filtering on multiple activity types.
 - An add/remove filter is added on edit activity for "With Contact" when > 20 to allow editing this field on large records.
 - A new filter is provided on the contact activities tab which uses a multi-select to allow filtering on campaigns and their sub-campaigns.
-- Some columns can be shown/hidden by configuring settings.
-- Case activities can optionally be shown.
+- Case activities can optionally be shown on the contact activities tab.
+- Some columns in the activities tab can optionally be shown/hidden:
+  - Target Contact 
+  - Duration
+  - Campaign Title
+  - Case
 
 ## Requirements
 - Requires campaign extension (for campaigntree API) to search for activities of child campaigns in contact activity tab.
-- Requires fontawesome extension for displaying icons (for various icons / engagement level): https://github.com/mattwire/uk.co.mjwconsult.fontawesome
+- 4.6 Only: Requires fontawesome extension for displaying icons (for various icons / engagement level): https://github.com/mattwire/uk.co.mjwconsult.fontawesome

--- a/fastactivity.civix.php
+++ b/fastactivity.civix.php
@@ -3,6 +3,83 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Fastactivity_ExtensionUtil {
+  const SHORT_NAME = "fastactivity";
+  const LONG_NAME = "de.systopia.fastactivity";
+  const CLASS_PREFIX = "CRM_Fastactivity";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = array(self::LONG_NAME, NULL);
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Fastactivity_ExtensionUtil as E;
+
+/**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
@@ -190,7 +267,7 @@ function _fastactivity_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'de.systopia.fastactivity';
+        $e['module'] = E::LONG_NAME;
       }
       $entities[] = $e;
       if (empty($e['params']['version'])) {
@@ -222,7 +299,7 @@ function _fastactivity_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => 'de.systopia.fastactivity',
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     );
@@ -248,7 +325,7 @@ function _fastactivity_civix_civicrm_angularModules(&$angularModules) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = 'de.systopia.fastactivity';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
   }

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/mattwire/de.systopia.fastactivity/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2018-08-03</releaseDate>
-  <version>1.4.mjwconsult1</version>
+  <releaseDate>2018-08-29</releaseDate>
+  <version>1.5.mjwconsult1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.6</ver>

--- a/info.xml
+++ b/info.xml
@@ -9,18 +9,19 @@
     <email>mjw@mjwconsult.co.uk</email>
   </maintainer>
   <urls>
-    <url desc="Main Extension Page">https://github.com/systopia/de.systopia.fastactivity</url>
-    <url desc="Documentation">https://github.com/systopia/de.systopia.fastactivity</url>
-    <url desc="Support">https://github.com/systopia/de.systopia.fastactivity/issues</url>
+    <url desc="Main Extension Page">https://github.com/mattwire/de.systopia.fastactivity</url>
+    <url desc="Documentation">https://github.com/mattwire/de.systopia.fastactivity</url>
+    <url desc="Support">https://github.com/mattwire/de.systopia.fastactivity/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2017-09-25</releaseDate>
-  <version>1.1.mjwconsult2</version>
+  <releaseDate>2017-11-07</releaseDate>
+  <version>1.2.mjwconsult1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.6</ver>
+    <ver>4.7</ver>
   </compatibility>
-  <comments>Developed by Matthew Wire</comments>
+  <comments>Developed by Matthew Wire and Systopia</comments>
   <civix>
     <namespace>CRM/Fastactivity</namespace>
   </civix>

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/mattwire/de.systopia.fastactivity/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2018-06-27</releaseDate>
-  <version>1.3.mjwconsult2</version>
+  <releaseDate>2018-07-05</releaseDate>
+  <version>1.3.mjwconsult3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.6</ver>

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/mattwire/de.systopia.fastactivity/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2018-06-13</releaseDate>
-  <version>1.3.mjwconsult1</version>
+  <releaseDate>2018-06-27</releaseDate>
+  <version>1.3.mjwconsult2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.6</ver>

--- a/info.xml
+++ b/info.xml
@@ -14,12 +14,13 @@
     <url desc="Support">https://github.com/mattwire/de.systopia.fastactivity/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2017-11-07</releaseDate>
-  <version>1.2.mjwconsult1</version>
+  <releaseDate>2018-06-13</releaseDate>
+  <version>1.3.mjwconsult1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.6</ver>
     <ver>4.7</ver>
+    <ver>5.0</ver>
   </compatibility>
   <comments>Developed by Matthew Wire and Systopia</comments>
   <civix>

--- a/info.xml
+++ b/info.xml
@@ -5,8 +5,8 @@
   <description>High Performance Activity Features</description>
   <license>AGPL-3.0</license>
   <maintainer>
-    <author>SYSTOPIA</author>
-    <email>endres@systopia.de</email>
+    <author>Matthew Wire</author>
+    <email>mjw@mjwconsult.co.uk</email>
   </maintainer>
   <urls>
     <url desc="Main Extension Page">https://github.com/systopia/de.systopia.fastactivity</url>
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/systopia/de.systopia.fastactivity/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2017-07-27</releaseDate>
-  <version>1.0.alpha2</version>
+  <releaseDate>2017-09-24</releaseDate>
+  <version>1.1.mjwconsult1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.6</ver>

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/systopia/de.systopia.fastactivity/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2017-09-24</releaseDate>
-  <version>1.1.mjwconsult1</version>
+  <releaseDate>2017-09-25</releaseDate>
+  <version>1.1.mjwconsult2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.6</ver>

--- a/info.xml
+++ b/info.xml
@@ -14,9 +14,9 @@
     <url desc="Support">https://github.com/mattwire/de.systopia.fastactivity/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2018-07-05</releaseDate>
-  <version>1.3.mjwconsult3</version>
-  <develStage>alpha</develStage>
+  <releaseDate>2018-08-03</releaseDate>
+  <version>1.4.mjwconsult1</version>
+  <develStage>stable</develStage>
   <compatibility>
     <ver>4.6</ver>
     <ver>4.7</ver>

--- a/settings/fastactivity.setting.php
+++ b/settings/fastactivity.setting.php
@@ -67,6 +67,20 @@ return array(
     'html_attributes' => array(),
   ),
 
+  'fastactivity_tab_col_case' => array(
+    'group_name' => 'FastActivity Settings',
+    'group' => 'fastactivity',
+    'name' => 'fastactivity_tab_col_case',
+    'type' => 'Boolean',
+    'html_type' => 'Checkbox',
+    'default' => 0,
+    'add' => '4.6',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Display Case column in contact tab',
+    'html_attributes' => array(),
+  ),
+
   'fastactivity_tab_exclude_case_activities' => array(
     'group_name' => 'FastActivity Settings',
     'group' => 'fastactivity',

--- a/settings/fastactivity.setting.php
+++ b/settings/fastactivity.setting.php
@@ -1,0 +1,83 @@
+<?php
+/*--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
++--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
++--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +-------------------------------------------------------------------*/
+
+return array(
+
+  'fastactivity_tab_col_duration' => array(
+    'group_name' => 'FastActivity Settings',
+    'group' => 'fastactivity',
+    'name' => 'fastactivity_tab_col_duration',
+    'type' => 'Boolean',
+    'html_type' => 'Checkbox',
+    'default' => 0,
+    'add' => '4.6',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Display Duration column in contact tab',
+    'html_attributes' => array(),
+  ),
+
+  'fastactivity_tab_col_target_contact' => array(
+    'group_name' => 'FastActivity Settings',
+    'group' => 'fastactivity',
+    'name' => 'fastactivity_tab_col_target_contact',
+    'type' => 'Boolean',
+    'html_type' => 'Checkbox',
+    'default' => 0,
+    'add' => '4.6',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Display Target Contact column in contact tab',
+    'html_attributes' => array(),
+  ),
+
+  'fastactivity_tab_col_campaign_title' => array(
+    'group_name' => 'FastActivity Settings',
+    'group' => 'fastactivity',
+    'name' => 'fastactivity_tab_col_campaign_title',
+    'type' => 'Boolean',
+    'html_type' => 'Checkbox',
+    'default' => 0,
+    'add' => '4.6',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Display Campaign Title column in contact tab',
+    'html_attributes' => array(),
+  ),
+
+  'fastactivity_tab_exclude_case_activities' => array(
+    'group_name' => 'FastActivity Settings',
+    'group' => 'fastactivity',
+    'name' => 'fastactivity_tab_exclude_case_activities',
+    'type' => 'Boolean',
+    'html_type' => 'Checkbox',
+    'default' => 1,
+    'add' => '4.6',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Exclude Case Activities from the activity tab',
+    'html_attributes' => array(),
+  ),
+);

--- a/templates/CRM/Fastactivity/Form/Add.tpl
+++ b/templates/CRM/Fastactivity/Form/Add.tpl
@@ -93,6 +93,7 @@
       <td class="label">{$form.subject.label}</td><td class="view-value">{$form.subject.html|crmAddClass:huge}</td>
     </tr>
 
+    {if $campaignEnabled}
     {* CRM-7362 --add campaign to activities *}
     {include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
     campaignTrClass="crm-activity-form-block-campaign_id"}
@@ -103,6 +104,7 @@
         <td class="label">{$form.engagement_level.label}</td>
         <td class="view-value">{$form.engagement_level.html}</td>
       </tr>
+    {/if}
     {/if}
 
     <tr class="crm-activity-form-block-location">

--- a/templates/CRM/Fastactivity/Form/Add.tpl
+++ b/templates/CRM/Fastactivity/Form/Add.tpl
@@ -18,8 +18,8 @@
 {if $cdType }
   {include file="CRM/Custom/Form/CustomData.tpl"}
 {else}
-  <h3>{$activityHeader}</h3>
-  {if $activityTypeDescription }
+  <h2>{$activityHeader}</h2>
+  {if $activityTypeDescription}
     <div class="help">Description: {$activityTypeDescription}</div>
   {/if}
   <div class="crm-block crm-form-block crm-activity-form-block">

--- a/templates/CRM/Fastactivity/Form/Add.tpl
+++ b/templates/CRM/Fastactivity/Form/Add.tpl
@@ -259,7 +259,6 @@ CRM.$(function($) {
 {/literal}
   </div>{* end of form block*}
 {/if}
-{include file="CRM/Event/Form/ManageEvent/ConfirmRepeatMode.tpl" entityID=$activityId entityTable="civicrm_activity"}
 
 {if $actionLinks}
   <div class="actionlinks">
@@ -270,3 +269,45 @@ CRM.$(function($) {
     {/foreach}
   </div>
 {/if}
+
+{literal}
+<script type="text/javascript">
+  CRM.$(function($) {
+    var $form = $('form.{/literal}{$form.formClass}{literal}');
+
+    function validate() {
+      var valid = $(':input', '#recurring-entity-block').valid(),
+        modified = CRM.utils.initialValueChanged('#recurring-entity-block');
+      $('#allowRepeatConfigToSubmit', $form).val(valid && modified ? '1' : '0');
+      return valid;
+    }
+
+    // Dialog for preview repeat Configuration dates
+    function previewDialog() {
+      // Set default value for start date on activity forms before generating preview
+      if (!$('#repetition_start_date', $form).val() && $('#activity_date_time', $form).val()) {
+        $('#repetition_start_date', $form)
+          .val($('#activity_date_time', $form).val())
+          .next().val($('#activity_date_time', $form).next().val())
+          .siblings('.hasTimeEntry').val($('#activity_date_time', $form).siblings('.hasTimeEntry').val());
+      }
+      var payload = $form.serialize() + '{/literal}&entity_table={$entityTable}&entity_id={$currentEntityId}{literal}';
+      CRM.confirm({
+        width: '50%',
+        url: CRM.url("civicrm/recurringentity/preview", payload)
+      }).on('crmConfirm:yes', function() {
+        $form.submit();
+      });
+    }
+
+    $('#_qf_Add_upload-top, #_qf_Add_upload-bottom').click(function (e) {
+      if (CRM.utils.initialValueChanged('#recurring-entity-block')) {
+        e.preventDefault();
+        if (validate()) {
+          previewDialog();
+        }
+      }
+    });
+  });
+</script>
+{/literal}

--- a/templates/CRM/Fastactivity/Form/Add.tpl
+++ b/templates/CRM/Fastactivity/Form/Add.tpl
@@ -29,7 +29,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 
   <table class="form-layout">
-    <div style="display:none">{$form.activity_type_id.html}</div>
+    <div>{$form.activity_type_id.html}</div>
     {if $surveyActivity}
       <tr class="crm-activity-form-block-survey">
         <td class="label">{ts}Survey Title{/ts}</td><td class="view-value">{$surveyTitle}</td>

--- a/templates/CRM/Fastactivity/Form/Settings.hlp
+++ b/templates/CRM/Fastactivity/Form/Settings.hlp
@@ -1,0 +1,36 @@
+{*--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +-------------------------------------------------------------------*}
+
+{htxt id='tab_col_duration'}
+{ts}Display the duration of the activity as a column in the activity tab{/ts}
+{/htxt}
+{htxt id='tab_col_campaign_title'}
+{ts}Display the campaign title associated with the activity as a column in the activity tab. NOTE: REQUIRES extension de.systopia.campaigntree{/ts}
+{/htxt}
+{htxt id='tab_col_target_contact'}
+{ts}Display the Target "With Contacts" as a column in the activity tab{/ts}
+{/htxt}
+{htxt id='tab_exclude_case_activities'}
+{ts}Exclude Case Activities from the activities tab (this is the default in the standard activities tab){/ts}
+{/htxt}

--- a/templates/CRM/Fastactivity/Form/Settings.tpl
+++ b/templates/CRM/Fastactivity/Form/Settings.tpl
@@ -22,23 +22,31 @@
 | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
 +-------------------------------------------------------------------*}
 
-<label class="crm-block crm-form-block crm-fastactivity-settings-form-block">
+<div class="crm-block crm-form-block crm-fastactivity-settings-form-block">
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="top"}
   </div>
 
-  <h3>Configuration</h3>
-  <table class="form-layout-compressed"><tbody>
-    {foreach from=$elementNames item=elementName}
-      <tr><td>
-          <label for="{$elementName}">{$form.$elementName.label} {help id=$elementName title=$form.$elementName.label}</label>
-          {$form.$elementName.html}
-        </td></tr>
-    {/foreach}
-    </tbody></table>
+  <h2>Configuration</h2>
+
+  {foreach from=$elementGroups item=elementGroup}
+    <div class="clear">
+      <br />
+      <h3>{$elementGroup.title}</h3>
+      <div class="help">{$elementGroup.description}</div>
+      <table class="form-layout-compressed">
+        {foreach from=$elementGroup.elementNames item=elementName}
+          <tr><td>
+              {$form.$elementName.html}
+              <label for="{$elementName}">{$form.$elementName.label} {help id=$elementName title=$form.$elementName.label}</label>
+            </td></tr>
+        {/foreach}
+      </table>
+    </div>
+  {/foreach}
 
   {* FOOTER *}
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
-  </div>
+</div>

--- a/templates/CRM/Fastactivity/Form/Settings.tpl
+++ b/templates/CRM/Fastactivity/Form/Settings.tpl
@@ -1,0 +1,44 @@
+{*--------------------------------------------------------------------+
+| CiviCRM version 4.7                                                |
++--------------------------------------------------------------------+
+| Copyright CiviCRM LLC (c) 2004-2017                                |
++--------------------------------------------------------------------+
+| This file is a part of CiviCRM.                                    |
+|                                                                    |
+| CiviCRM is free software; you can copy, modify, and distribute it  |
+| under the terms of the GNU Affero General Public License           |
+| Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+|                                                                    |
+| CiviCRM is distributed in the hope that it will be useful, but     |
+| WITHOUT ANY WARRANTY; without even the implied warranty of         |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+| See the GNU Affero General Public License for more details.        |
+|                                                                    |
+| You should have received a copy of the GNU Affero General Public   |
+| License and the CiviCRM Licensing Exception along                  |
+| with this program; if not, contact CiviCRM LLC                     |
+| at info[AT]civicrm[DOT]org. If you have questions about the        |
+| GNU Affero General Public License or the licensing of CiviCRM,     |
+| see the CiviCRM license FAQ at http://civicrm.org/licensing        |
++-------------------------------------------------------------------*}
+
+<label class="crm-block crm-form-block crm-fastactivity-settings-form-block">
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="top"}
+  </div>
+
+  <h3>Configuration</h3>
+  <table class="form-layout-compressed"><tbody>
+    {foreach from=$elementNames item=elementName}
+      <tr><td>
+          <label for="{$elementName}">{$form.$elementName.label} {help id=$elementName title=$form.$elementName.label}</label>
+          {$form.$elementName.html}
+        </td></tr>
+    {/foreach}
+    </tbody></table>
+
+  {* FOOTER *}
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+  </div>

--- a/templates/CRM/Fastactivity/Form/View.tpl
+++ b/templates/CRM/Fastactivity/Form/View.tpl
@@ -133,7 +133,6 @@
         {/if}
       </td>
     </tr>
-    {/if}
     <tr class="crm-activity-form-block-activity_engagementlevel">
       <td class="label">Engagement Index</td>
       <td class="view-value">
@@ -144,6 +143,7 @@
         {/if}
       </td>
     </tr>
+    {/if}
     <tr class="crm-activity-form-block-activity_subject">
       <td class="label">Subject</td>
       <td class="view-value">{$activity.subject}</td>

--- a/templates/CRM/Fastactivity/Form/View.tpl
+++ b/templates/CRM/Fastactivity/Form/View.tpl
@@ -19,39 +19,36 @@
 
 {if $action eq 8} {* delete activity *}
   <table class="crm-info-panel">
-    <h3><i class="crm-i fa-question-circle" aria-hidden="true"></i>
-      {$activityHeader}
+    <h3><span><i class="crm-i fa-question-circle" aria-hidden="true" /> {$activityHeader}</span>
     </h3>
     <tr class="crm-activity-form-block-activity_type">
-      <td class="label">Type</td>
-      <td class="view-value">{$activity.typeName}</td>
+      <td class="label">{ts}Type{/ts}</td>
+      <td class="view-value">{$activity.typeName}&nbsp;</td>
     </tr>
     <tr class="crm-activity-form-block-activity_subject">
-      <td class="label">Subject</td>
-      <td class="view-value">{$activity.subject}</td>
+      <td class="label">{ts}Subject{/ts}</td>
+      <td class="view-value">{$activity.subject}&nbsp;</td>
     </tr>
     <tr class="crm-activity-form-block-activity_date_time">
       <td class="label">
-        <i class="crm-i fa-calendar" aria-hidden="true"></i>
-        Date
+        <span><i class="crm-i fa-calendar" aria-hidden="true" /> {ts}Date{/ts}</span>
       </td>
-      <td class="view-value">{$activity.dateTime|crmDate}</td>
+      <td class="view-value">{$activity.dateTime|crmDate}&nbsp;</td>
     </tr>
     <tr class="crm-activity-form-block-activity_status">
-      <td class="label">Status</td>
-      <td class="view-value">{$activity.status}</td>
+      <td class="label">{ts}Status{/ts}</td>
+      <td class="view-value">{$activity.status}&nbsp;</td>
     </tr>
   </table>
 {else}
   <table class="crm-info-panel">
     <h3>{$activityHeader}</h3>
     {if $activity.typeDescription}
-      <div class="help">Description: {$activity.typeDescription}</div>
+      <div class="help">{ts}Description{/ts}: {$activity.typeDescription}</div>
     {/if}
     <tr class="crm-activity-form-block-source_contact_id">
       <td class="label">
-        <i class="crm-i fa-user" aria-hidden="true"></i>
-        Added By
+        <span><i class="crm-i fa-user" aria-hidden="true" /> {ts}Added By{/ts}</span>
       </td>
       <td class="view-value">
         {counter start=1 assign=count}
@@ -63,12 +60,12 @@
           {/if}
           {counter}
         {/foreach}
+        &nbsp;
       </td>
     </tr>
     <tr class="crm-activity-form-block-assignee_contact_id">
       <td class="label">
-        <i class="crm-i fa-user" aria-hidden="true"></i>
-        Assigned To
+        <span><i class="crm-i fa-user" aria-hidden="true" /> {ts}Assigned To{/ts}</span>
       </td>
       <td class="view-value">
         {counter start=1 assign=count}
@@ -80,16 +77,16 @@
           {/if}
           {counter}
         {/foreach}
+        &nbsp;
       </td>
     </tr>
     <tr class="crm-activity-form-block-target_contact_id">
       <td class="label">
-        <i class="crm-i fa-users" aria-hidden="true"></i>
-        With
+        <span><i class="crm-i fa-users" aria-hidden="true" /> {ts}With{/ts}</span>
       </td>
       <td class="view-value">
         {if $activity.targetContacts|@count lt $activity.targetContacts.count}
-          {$activity.targetContacts.count} contacts
+          {$activity.targetContacts.count} {ts}contacts{/ts}
         {else}
           {counter start=1 assign=count}
           {foreach from=$activity.targetContacts item=contact}
@@ -100,60 +97,67 @@
             {/if}
             {counter}
           {/foreach}
+          &nbsp;
         {/if}
       </td>
     </tr>
     <tr class="crm-activity-form-block-activity_date_time">
       <td class="label">
-        <i class="crm-i fa-calendar" aria-hidden="true"></i>
-        Date
+        <span><i class="crm-i fa-calendar" aria-hidden="true" /> {ts}Date{/ts}</span>
       </td>
-      <td class="view-value">{$activity.dateTime|crmDate}</td>
+      <td class="view-value">{$activity.dateTime|crmDate}&nbsp;</td>
+    </tr>
+    <tr class="crm-activity-form-block-activity_duration">
+      <td class="label">
+        <span><i class="crm-i fa-calendar" aria-hidden="true" /> {ts}Duration{/ts}</span>
+      </td>
+      <td class="view-value">{$activity.duration}&nbsp;</td>
     </tr>
     <tr class="crm-activity-form-block-activity_status">
-      <td class="label">Status</td>
-      <td class="view-value">{$activity.status}</td>
+      <td class="label">{ts}Status{/ts}</td>
+      <td class="view-value">{$activity.status}&nbsp;</td>
     </tr>
     <tr class="crm-activity-form-block-activity_priority">
-      <td class="label">Priority</td>
-      <td class="view-value">{$activity.priority}</td>
+      <td class="label">{ts}Priority{/ts}</td>
+      <td class="view-value">{$activity.priority}&nbsp;</td>
     </tr>
     <tr class="crm-activity-form-block-activity_medium">
-      <td class="label">Medium</td>
-      <td class="view-value">{if $activity.medium}{$activity.medium}{else}{/if}</td>
+      <td class="label">{ts}Medium{/ts}</td>
+      <td class="view-value">{if $activity.medium}{$activity.medium}{else}&nbsp;{/if}</td>
     </tr>
     {if $campaignEnabled}
     <tr class="crm-activity-form-block-activity_campaign">
-      <td class="label">Campaign</td>
+      <td class="label">{ts}Campaign{/ts}</td>
       <td class="view-value">
         {if $activity.campaignId}
           {assign var=campaignId value=$activity.campaignId}
           {capture assign=campaignViewURL}{crmURL p="civicrm/a/#/campaign/$campaignId/view" q="reset=1"}{/capture}
           <a href="{$campaignViewURL}" target="_blank" class="action-item crm-hover-button no-popup">{$activity.campaign}</a>
         {/if}
+        &nbsp;
       </td>
     </tr>
     <tr class="crm-activity-form-block-activity_engagementlevel">
-      <td class="label">Engagement Index</td>
+      <td class="label">{ts}Engagement Index{/ts}</td>
       <td class="view-value">
         {if $activity.engagementLevelStars}
           {$activity.engagementLevelStars}
         {else}
           {$activity.engagementLevel}
         {/if}
+        &nbsp;
       </td>
     </tr>
     {/if}
     <tr class="crm-activity-form-block-activity_subject">
-      <td class="label">Subject</td>
-      <td class="view-value">{$activity.subject}</td>
+      <td class="label">{ts}Subject{/ts}</td>
+      <td class="view-value">{$activity.subject}&nbsp;</td>
     </tr>
     <tr class="crm-activity-form-block-activity_details">
       <td class="label">
-        <i class="crm-i fa-info" aria-hidden="true"></i>
-        Details
+        <label><span><i class="crm-i fa-info" aria-hidden="true" /> {ts}Details{/ts}</span></label>
       </td>
-      <td class="view-value">{$activity.details}</td>
+      <td class="view-value">{$activity.details}&nbsp;</td>
     </tr>
     {foreach from=$viewCustomData item=customGroup}
       <tr class="crm-activity-form-block-custom_data">
@@ -167,7 +171,7 @@
                   {foreach from=$customFields.fields item=fields}
                     <tr>
                       <td class="label">{$fields.field_title}</td>
-                      <td class="view-value">{$fields.field_value}</td>
+                      <td class="view-value">{$fields.field_value}&nbsp;</td>
                     </tr>
                   {/foreach}
                 </table>

--- a/templates/CRM/Fastactivity/Form/View.tpl
+++ b/templates/CRM/Fastactivity/Form/View.tpl
@@ -122,6 +122,7 @@
       <td class="label">Medium</td>
       <td class="view-value">{if $activity.medium}{$activity.medium}{else}{/if}</td>
     </tr>
+    {if $campaignEnabled}
     <tr class="crm-activity-form-block-activity_campaign">
       <td class="label">Campaign</td>
       <td class="view-value">
@@ -132,6 +133,7 @@
         {/if}
       </td>
     </tr>
+    {/if}
     <tr class="crm-activity-form-block-activity_engagementlevel">
       <td class="label">Engagement Index</td>
       <td class="view-value">

--- a/templates/CRM/Fastactivity/Form/View.tpl
+++ b/templates/CRM/Fastactivity/Form/View.tpl
@@ -41,8 +41,18 @@
     </tr>
   </table>
 {else}
+  <h2>{$activityHeader}</h2>
   <table class="crm-info-panel">
-    <h3>{$activityHeader}</h3>
+    {if $activity.case_id gt 0}
+    <h3>
+      {ts}Filed on Case:{/ts}
+      {assign var=contactId value=$activity.contactId}
+      {assign var=caseId value=$activity.case_id}
+      {capture assign=caseViewURL}{crmURL p='civicrm/contact/view/case' q="reset=1&id=$caseId&cid=$contactId&action=view&context=case"}{/capture}
+      <a href="{$caseViewURL}" class="action-item crm-hover-button no-popup" target="_blank">{$activity.case_subject} ({$activity.case_type})</a>
+    </h3>
+    {/if}
+
     {if $activity.typeDescription}
       <div class="help">{ts}Description{/ts}: {$activity.typeDescription}</div>
     {/if}

--- a/templates/CRM/Fastactivity/Selector/Selector.tpl
+++ b/templates/CRM/Fastactivity/Selector/Selector.tpl
@@ -27,10 +27,12 @@
               <td class="label">{$form.activity_type_id.label}</td>
               <td class="view-value">{$form.activity_type_id.html|crmAddClass:fullwidth}</td>
             </tr>
+            {if $optionalCols.campaign_title}
             <tr>
               <td class="label">{$form.activity_campaign_id.label}</td>
               <td class="view-value">{$form.activity_campaign_id.html|crmAddClass:fullwidth}</td>
             </tr>
+            {/if}
           </table>
           </div>
         </div>
@@ -41,12 +43,19 @@
     <tr>
       <th class='crm-contact-activity-activity_type'>{ts}Type{/ts}</th>
       <th class='crm-contact-activity_subject'>{ts}Subject{/ts}</th>
-      <th class='crm-contact-activity-activity_campaign'>{ts}Campaign{/ts}</th>
+      {if $optionalCols.campaign_title}
+        <th class='crm-contact-activity-activity_campaign'>{ts}Campaign{/ts}</th>
+      {/if}
       <th class='crm-contact-activity-source_contact'>{ts}Added By{/ts}</th>
-      <!-- <th class='crm-contact-activity-target_contact nosort'>{ts}With{/ts}</th> we are not showing target contact column -->
+      {if $optionalCols.target_contact}
+        <th class='crm-contact-activity-target_contact nosort'>{ts}With{/ts}</th>
+      {/if}
       <th class='crm-contact-activity-assignee_contact'>{ts}Assigned{/ts}</th>
       <th class='crm-contact-activity-activity_date'>{ts}Date{/ts}</th>
       <th class='crm-contact-activity-activity_status'>{ts}Status{/ts}</th>
+      {if $optionalCols.duration}
+        <th class='crm-contact-activity-duration nosort'>{ts}Duration{/ts}</th>
+      {/if}
       <th class='crm-contact-activity-links nosort'>&nbsp;</th>
       <th class='hiddenElement'>&nbsp;</th>
     </tr>
@@ -97,12 +106,19 @@ CRM.$(function($) {
       "aoColumns"  : [
         {sClass:'crm-contact-activity-activity_type'},
         {sClass:'crm-contact-activity_subject'},
-        {sClass:'crm-contact-activity-activity_campaign'},
+        {/literal}{if $optionalCols.campaign_title}{literal}
+          {sClass:'crm-contact-activity-activity_campaign'},
+        {/literal}{/if}{literal}
         {sClass:'crm-contact-activity-source_contact'},
-        <!-- {sClass:'crm-contact-activity-target_contact', bSortable:false}, we are not showing target contact column -->
+        {/literal}{if $optionalCols.target_contact}{literal}
+          {sClass:'crm-contact-activity-target_contact'},
+        {/literal}{/if}{literal}
         {sClass:'crm-contact-activity-assignee_contact'},
         {sClass:'crm-contact-activity-activity_date'},
         {sClass:'crm-contact-activity-activity_status'},
+        {/literal}{if $optionalCols.duration}{literal}
+          {sClass:'crm-contact-activity-duration'},
+        {/literal}{/if}{literal}
         {sClass:'crm-contact-activity-links', bSortable:false},
         {sClass:'hiddenElement', bSortable:false}
       ],
@@ -136,8 +152,10 @@ CRM.$(function($) {
 
         if ( filterSearch ) {
           aoData.push(
-            {name:'activity_type_id', value: $('.crm-activity-selector-'+ context +' select#activity_type_id').val()},
-            {name:'activity_campaign_id', value: $('.crm-activity-selector-'+ context +' select#campaigns').val()}
+            {name:'activity_type_id', value: $('.crm-activity-selector-'+ context +' select#activity_type_id').val()}
+            {/literal}{if $optionalCols.campaign_title}{literal}
+            ,{name:'activity_campaign_id', value: $('.crm-activity-selector-'+ context +' select#campaigns').val()}
+            {/literal}{/if}{literal}
           );
         }
         $.ajax( {

--- a/templates/CRM/Fastactivity/Selector/Selector.tpl
+++ b/templates/CRM/Fastactivity/Selector/Selector.tpl
@@ -56,6 +56,9 @@
       {if $optionalCols.duration}
         <th class='crm-contact-activity-duration nosort'>{ts}Duration{/ts}</th>
       {/if}
+      {if $optionalCols.case}
+        <th class='crm-contact-activity-case nosort'>{ts}Case{/ts}</th>
+      {/if}
       <th class='crm-contact-activity-links nosort'>&nbsp;</th>
       <th class='hiddenElement'>&nbsp;</th>
     </tr>
@@ -118,6 +121,9 @@ CRM.$(function($) {
         {sClass:'crm-contact-activity-activity_status'},
         {/literal}{if $optionalCols.duration}{literal}
           {sClass:'crm-contact-activity-duration'},
+        {/literal}{/if}{literal}
+        {/literal}{if $optionalCols.case}{literal}
+          {sClass:'crm-contact-activity-case'},
         {/literal}{/if}{literal}
         {sClass:'crm-contact-activity-links', bSortable:false},
         {sClass:'hiddenElement', bSortable:false}

--- a/xml/Menu/fastactivity.xml
+++ b/xml/Menu/fastactivity.xml
@@ -23,4 +23,10 @@
     <title>Add</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/admin/fastactivity</path>
+    <page_callback>CRM_Fastactivity_Form_Settings</page_callback>
+    <title>Settings</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
Creating this PR so changes can be reviewed so we can get it ready for merge.
(Campaign element changes have not been fully tested).

* CRM_Core_BAO_Setting::flushCache/inCache don't exist on 4.7
* Add settings page. Add options to show/hide duration,campaign,target_contact. Add option to show/hide case activities
* Don't display campaign elements when civicampaign is disabled