### PR TITLE
GP-1955: Fix target contact being cleared

### DIFF
--- a/CRM/Fastactivity/Form/Add.php
+++ b/CRM/Fastactivity/Form/Add.php
@@ -238,7 +238,7 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
 
     if (!empty($this->_submitValues)) {
       $this->_values = $this->_submitValues;
-      if (isset($this->_submitValues['target_contact_count'])) {
+      if (isset($this->_submitValues['target_contact_count']) && $this->_submitValues['target_contact_count'] > $this::MAX_TARGETCONTACTS) {
         $this->_activityTargetCount = $this->_submitValues['target_contact_count'];
         $this->assign('activityTargetCount', $this->_activityTargetCount);
       }


### PR DESCRIPTION
This fixes a bug where the target contact is cleared if an activity is edited and a form/validation error occurs prior to the activity being saved successfully. Only activities with <= 20 target contacts were affected by this.