### PR TITLE
Fix tab count when showing case activities

### DIFF
--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -200,6 +200,13 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
     $activity_type_id = CRM_Utils_Array::value('activity_type_id', $params);
     $excludeCaseActivities = CRM_Utils_Array::value('excludeCaseActivities', $params, TRUE);
 
+    // contact_id
+    $contact_id = CRM_Utils_Array::value('contact_id', $params);
+    if ($contact_id) {
+      $clauses[] = "acon.contact_id = %1";
+      $params[1] = array($contact_id, 'Integer');
+    }
+
     if (!empty($activity_type_id)) {
       $clauses[] = "activity.activity_type_id IN ( " . $activity_type_id . " ) ";
     }
@@ -243,13 +250,6 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
     }
 
-    // contact_id
-    $contact_id = CRM_Utils_Array::value('contact_id', $params);
-    if ($contact_id) {
-      $clauses[] = "acon.contact_id = %1";
-      $params[1] = array($contact_id, 'Integer');
-    }
-
     return implode(' AND ', $clauses);
   }
 
@@ -269,13 +269,12 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
    *   count of activities
    */
   public static function getContactActivitiesCount(&$params) {
-
     $whereClause = self::whereClause($params, FALSE);
 
     $query = "SELECT COUNT(DISTINCT acon.activity_id)
               FROM civicrm_activity_contact acon
               LEFT JOIN civicrm_activity activity ON acon.activity_id = activity.id ";
-    if ($params['excludeCaseActivities']) {
+    if (!$params['excludeCaseActivities']) {
       $query .= 'LEFT JOIN civicrm_case_activity case_activity ON (activity.id = case_activity.activity_id) ';
     }
     $query .= " WHERE {$whereClause}";

--- a/CRM/Fastactivity/Page/Tab.php
+++ b/CRM/Fastactivity/Page/Tab.php
@@ -25,7 +25,6 @@ class CRM_Fastactivity_Page_Tab extends CRM_Core_Page {
   /**
    * Browse all activities for a particular contact.
    *
-   * @return void
    */
   public function browse() {
     $this->assign('admin', FALSE);
@@ -49,14 +48,13 @@ class CRM_Fastactivity_Page_Tab extends CRM_Core_Page {
     $controller->set('contactId', $this->_contactId);
     $controller->setEmbedded(TRUE);
     $controller->run();
-    $this->ajaxResponse['tabCount'] = CRM_Contact_BAO_Contact::getCountComponent('activity', $this->_contactId);
   }
 
   /**
    * Heart of the viewing process. The runner gets all the meta data for
    * the contact and calls the appropriate type of page to view.
    *
-   * @return void
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
     $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
@@ -84,7 +82,7 @@ class CRM_Fastactivity_Page_Tab extends CRM_Core_Page {
   /**
    * Run the activities "tab" page
    *
-   * @return void
+   * @throws \CRM_Core_Exception
    */
   public function run() {
     $action = CRM_Utils_Request::retrieve('action', 'String', $this);
@@ -104,6 +102,6 @@ class CRM_Fastactivity_Page_Tab extends CRM_Core_Page {
     $this->preProcess();
     $this->browse();
 
-    return parent::run();
+    parent::run();
   }
 }


### PR DESCRIPTION
* Fix tab count when showing case activities.
* Remove an unnecessary call to calculate count (it's still called twice but via AJAX so we can't use a static variable).

There's also a little bit of cleanup in here.