### PR TITLE
Remove ActivityJs.tpl as we don't use it

### DIFF
--- a/templates/CRM/Fastactivity/Form/Add.tpl
+++ b/templates/CRM/Fastactivity/Form/Add.tpl
@@ -24,8 +24,6 @@
   {/if}
   <div class="crm-block crm-form-block crm-activity-form-block">
 
-  {* added onload javascript for source contact*}
-  {include file="CRM/Activity/Form/ActivityJs.tpl" tokenContext="activity"}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 
   <table class="form-layout">


### PR DESCRIPTION
ActivityJs.tpl is not used by this extension but is referenced in the tpl.

See https://github.com/civicrm/civicrm-core/pull/13342 for background on why I found this issue!