### PR TITLE
Fix contact ID for link to case

### DIFF
--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -547,7 +547,7 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
       ));
       $label = "ID: {$caseId}<br />({$contactName})";
     }
-    $url = CRM_Utils_System::url('civicrm/contact/view/case', "reset=1&id={$caseId}&cid={$contactId}&action=view");
+    $url = CRM_Utils_System::url('civicrm/contact/view/case', "reset=1&id={$caseId}&cid={$firstCaseContactId}&action=view");
     $html = "<a href='$url' class='action-item crm-hover-button no-popup' target='_blank'>{$label}</a>";
     return $html;
   }


### PR DESCRIPTION
This is the link to a case on the activities tab.  It is possible for the activity to be linked to a case that has a different contact ID to the contact being viewed and this fixes the contact ID in that case.