### PR TITLE
Replace view/edit links in search results with fastactivity

### DIFF
--- a/fastactivity.php
+++ b/fastactivity.php
@@ -232,3 +232,27 @@ function fastactivity_civicrm_navigationMenu(&$menu) {
   );
   _fastactivity_civix_insert_navigation_menu($menu, 'Administer/Customize Data and Screens', $item[0]);
 }
+
+/**
+ * Replace activity view and edit links in search results
+ *
+ * @param $op
+ * @param $objectName
+ * @param $objectId
+ * @param $links
+ * @param $mask
+ * @param $values
+ */
+function fastactivity_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
+  $replace_search_links = (bool) CRM_Fastactivity_Settings::getValue('fastactivity_replace_search');
+  if ($replace_search_links && $op == 'activity.selector.row') {
+    foreach ($links as &$link) {
+      if ($link['name'] == 'View') {
+        $link['url'] = 'civicrm/fastactivity/view';
+      }
+      elseif ($link['name'] == 'Edit') {
+        $link['url'] = 'civicrm/fastactivity/add';
+      }
+    }
+  }
+}

--- a/settings/fastactivity.setting.php
+++ b/settings/fastactivity.setting.php
@@ -38,6 +38,20 @@ return array(
       'html_attributes' => array(),
   ),
 
+  'fastactivity_replace_search' => [
+    'group_name' => 'FastActivity Settings',
+    'group' => 'fastactivity',
+    'name' => 'fastactivity_replace_search',
+    'type' => 'Boolean',
+    'html_type' => 'Checkbox',
+    'default' => 0,
+    'add' => '4.6',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Replace view/edit links in activity search results',
+    'html_attributes' => [],
+  ],
+
   'fastactivity_tab_col_duration' => array(
     'group_name' => 'FastActivity Settings',
     'group' => 'fastactivity',


### PR DESCRIPTION
This adds a setting to allow replacement of the core activity view page and edit form with fastactivity in activity search results.