### PR TITLE
GP-8108 Adapt activity filter to match core

### DIFF
--- a/CRM/Fastactivity/Form/ActivityFilter.php
+++ b/CRM/Fastactivity/Form/ActivityFilter.php
@@ -28,7 +28,19 @@ class CRM_Fastactivity_Form_ActivityFilter extends CRM_Core_Form {
       'activity_type_id',
       array('entity' => 'Activity', 'label' => 'Activity Type(s)', 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))
     );
-
+    $this->addSelect(
+      'activity_type_exclude_id',
+      array('entity' => 'Activity', 'field' => 'activity_type_id', 'label' => 'Exclude Activity Type(s)', 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))
+    );
+    CRM_Core_Form_Date::buildDateRange(
+      $this, 'activity_date', 1,
+      '_low', '_high', ts('From'),
+      FALSE, array(), 'searchDate',
+      FALSE, array('class' => 'crm-select2 medium')
+    );
+    $this->addSelect('activity_status_id',
+      array('entity' => 'activity', 'multiple' => 'multiple', 'option_url' => NULL, 'placeholder' => ts('- any -'))
+    );
     $this->add(
       'select',
       'activity_campaign_id',
@@ -48,14 +60,16 @@ class CRM_Fastactivity_Form_ActivityFilter extends CRM_Core_Form {
     $defaults = array();
     $session = CRM_Core_Session::singleton();
     $userID = $session->get('userID');
-    if ($userID) {
+    if ($userID && Civi::settings()->get('preserve_activity_tab_filter')) {
       $defaults = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::PERSONAL_PREFERENCES_NAME,
         'activity_tab_filter',
         NULL,
         NULL,
         $userID
       );
+      $this->assign('activity_tab_filter', array_filter($defaults));
     }
+
     return $defaults;
   }
 

--- a/CRM/Fastactivity/Page/AJAX.php
+++ b/CRM/Fastactivity/Page/AJAX.php
@@ -84,11 +84,28 @@ class CRM_Fastactivity_Page_AJAX {
 
     // store the activity filter preference CRM-11761
     $userID = CRM_Core_Session::getLoggedInContactID();
-    if ($userID) {
+    if (Civi::settings()->get('preserve_activity_tab_filter') && $userID) {
       $activityFilter = array(
         'activity_type_id' => empty($params['activity_type_id']) ? '' : CRM_Utils_Type::escape($params['activity_type_id'], 'String'),
-        'activity_type_exclude_filter_id' => empty($params['activity_type_exclude_id']) ? '' : CRM_Utils_Type::escape($params['activity_type_exclude_id'], 'String'),
+        'activity_type_exclude_id' => empty($params['activity_type_exclude_id']) ? '' : CRM_Utils_Type::escape($params['activity_type_exclude_id'], 'String'),
+        'activity_date_relative' => empty($params['activity_date_relative']) ? '' : CRM_Utils_Type::escape($params['activity_date_relative'], 'String'),
+        'activity_status_id' => empty($params['activity_status_id']) ? '' : CRM_Utils_Type::escape($params['activity_status_id'], 'String'),
+        'activity_campaign_id' => empty($params['activity_campaign_id']) ? '' : CRM_Utils_Type::escape($params['activity_campaign_id'], 'String'),
       );
+      if (empty($params['activity_date_low'])) {
+        $activityFilter['activity_date_low'] = '';
+      }
+      else {
+        $activityFilter['activity_date_relative'] = 0;
+        $activityFilter['activity_date_low'] = CRM_Utils_Type::escape($params['activity_date_low'], 'String');
+      }
+      if (empty($params['activity_date_high'])) {
+        $activityFilter['activity_date_high'] = '';
+      }
+      else {
+        $activityFilter['activity_date_relative'] = 0;
+        $activityFilter['activity_date_high'] = CRM_Utils_Type::escape($params['activity_date_high'], 'String');
+      }
 
       CRM_Core_BAO_Setting::setItem(
         $activityFilter,

--- a/templates/CRM/Fastactivity/Selector/Selector.tpl
+++ b/templates/CRM/Fastactivity/Selector/Selector.tpl
@@ -14,7 +14,7 @@
 +-------------------------------------------------------*}
 
 <div class="crm-activity-selector-{$context}">
-  <div class="crm-accordion-wrapper crm-search_filters-accordion collapsed">
+  <div class="crm-accordion-wrapper crm-search_filters-accordion {if !$activity_tab_filter}collapsed{/if}">
     <div class="crm-accordion-header">
     {ts}Filter by Activity Type{/ts}</a>
     </div><!-- /.crm-accordion-header -->
@@ -22,17 +22,28 @@
       <div class="no-border form-layout-compressed" id="searchOptions">
         <div class="crm-contact-form-block-activity_type_id">
           <div class="crm-block crm-form-block crm-activity-search-form-block">
-          <table class="form-layout">
+          <table class="form-layout-compressed">
             <tr>
-              <td class="label">{$form.activity_type_id.label}</td>
-              <td class="view-value">{$form.activity_type_id.html|crmAddClass:fullwidth}</td>
+              <td class="{if $form.activity_type_id.value.0 && $activity_tab_filter}value-highlight{/if}">
+                {$form.activity_type_id.label}<br /> {$form.activity_type_id.html|crmAddClass:medium}
+              </td>
+              <td class="{if $form.activity_type_exclude_id.value.0 && $activity_tab_filter}value-highlight{/if}">
+                {$form.activity_type_exclude_id.label}<br /> {$form.activity_type_exclude_id.html|crmAddClass:medium}
+              </td>
+              <td class="{if $activity_tab_filter}{if $form.activity_date_relative.value.0 || $form.activity_date_low.value || $form.activity_date_high.value}value-highlight{/if}{/if}" colspan="2" >
+                <table>
+                  {include file="CRM/Core/DateRange.tpl" fieldName="activity_date" from='_low' to='_high' label='<label>Date</label>'}
+                </table>
+              </td>
+              <td class="{if $form.activity_status_id.value.0 && $activity_tab_filter}value-highlight{/if}">
+                {$form.activity_status_id.label}<br /> {$form.activity_status_id.html|crmAddClass:medium}
+              </td>
+              {if $optionalCols.campaign_title}
+                <td class="{if $form.activity_campaign_id.value.0 && $activity_tab_filter}value-highlight{/if}">
+                  {$form.activity_campaign_id.label}<br /> {$form.activity_campaign_id.html|crmAddClass:medium}
+                </td>
+              {/if}
             </tr>
-            {if $optionalCols.campaign_title}
-            <tr>
-              <td class="label">{$form.activity_campaign_id.label}</td>
-              <td class="view-value">{$form.activity_campaign_id.html|crmAddClass:fullwidth}</td>
-            </tr>
-            {/if}
           </table>
           </div>
         </div>
@@ -66,6 +77,18 @@
   </table>
 </div>
 {include file="CRM/Case/Form/ActivityToCase.tpl" contactID=$contactId}
+{if $activity_tab_filter}
+  {literal}
+  <style>
+    .crm-activity-selector-{/literal}{$context}{literal} .value-highlight .select2-choices,
+    .crm-activity-selector-{/literal}{$context}{literal} .value-highlight .select2-choice,
+    .crm-activity-selector-{/literal}{$context}{literal} .value-highlight .select2-arrow,
+    .crm-activity-selector-{/literal}{$context}{literal} .value-highlight .crm-absolute-date-range input {
+      background-color: #FFF6D8 !important;
+    }
+  </style>
+  {/literal}
+{/if}
 {literal}
 <script type="text/javascript">
 var {/literal}{$context}{literal}oTable;
@@ -77,11 +100,7 @@ CRM.$(function($) {
   }
   buildContactActivities{/literal}{$context}{literal}( filterSearchOnLoad );
 
-  $('.crm-activity-selector-'+ context +' #activity_type_id').change( function( ) {
-    buildContactActivities{/literal}{$context}{literal}( true );
-  });
-
-  $('.crm-activity-selector-'+ context +' #campaigns').change( function( ) {
+  $('.crm-activity-selector-'+ context +' :input').change( function( ) {
     buildContactActivities{/literal}{$context}{literal}( true );
   });
 
@@ -158,7 +177,12 @@ CRM.$(function($) {
 
         if ( filterSearch ) {
           aoData.push(
-            {name:'activity_type_id', value: $('.crm-activity-selector-'+ context +' select#activity_type_id').val()}
+            {name:'activity_type_id', value: $('.crm-activity-selector-'+ context +' select#activity_type_id').val()},
+            {name:'activity_type_exclude_id', value: $('.crm-activity-selector-'+ context +' select#activity_type_exclude_id').val()},
+            {name:'activity_date_relative', value: $('.crm-activity-selector-'+ context +' select#activity_date_relative').val()},
+            {name:'activity_date_low', value: $('.crm-activity-selector-'+ context +' input#activity_date_low').val()},
+            {name:'activity_date_high', value: $('.crm-activity-selector-'+ context +' input#activity_date_high').val()},
+            {name:'activity_status_id', value: $('.crm-activity-selector-'+ context +' select#activity_status_id').val()}
             {/literal}{if $optionalCols.campaign_title}{literal}
             ,{name:'activity_campaign_id', value: $('.crm-activity-selector-'+ context +' select#campaigns').val()}
             {/literal}{/if}{literal}


### PR DESCRIPTION
This changes the activity filter of the activity contact view to roughly match the latest core implementation (with minor improvements):

 - Change the UI to show all filter fields in one line
 - Add the ability to exclude activity types
 - Add filtering by activity date and status
 - Respect the activity filter preference in core
 - Highlight filter fields prefilled with a remembered value

Fixes #21