### PR TITLE
Add option for removing HTML from activity details

### DIFF
--- a/CRM/Fastactivity/DetailsFilterJob.php
+++ b/CRM/Fastactivity/DetailsFilterJob.php
@@ -18,9 +18,9 @@ use CRM_Fastactivity_ExtensionUtil as E;
 class CRM_Fastactivity_DetailsFilterJob {
 
   /**
-   * @var int $activityId
+   * @var int[] $activityIds
    */
-  protected $activityId;
+  protected $activityIds;
 
   /**
    * @var string $title
@@ -33,11 +33,11 @@ class CRM_Fastactivity_DetailsFilterJob {
    *
    * @param $activity_ids
    */
-  public function __construct($activity_id) {
-    $this->activityId = $activity_id;
+  public function __construct($activity_ids) {
+    $this->activityIds = $activity_ids;
     $this->title = E::ts(
-      'Filtering details for activity %1',
-      [1 => $activity_id]
+      'Filtering details for %1 activities',
+      [1 => count($activity_ids)]
     );
   }
 
@@ -45,20 +45,22 @@ class CRM_Fastactivity_DetailsFilterJob {
    * @throws \CiviCRM_API3_Exception
    */
   public function run() {
-    $activity = civicrm_api3(
-      'Activity',
-      'getsingle',
-      ['id' => $this->activityId],
-      ['return' => 'details']
-    );
-    civicrm_api3(
-      'Activity',
-      'create',
-      [
-        'id' => $this->activityId,
-        'details' => CRM_Utils_String::htmlToText($activity['details']),
-      ]
-    );
+    foreach ($this->activityIds as $activityId) {
+      $activity = civicrm_api3(
+        'Activity',
+        'getsingle',
+        ['id' => $activityId],
+        ['return' => 'details']
+      );
+      civicrm_api3(
+        'Activity',
+        'create',
+        [
+          'id' => $activityId,
+          'details' => CRM_Utils_String::htmlToText($activity['details']),
+        ]
+      );
+    }
 
     return TRUE;
   }

--- a/CRM/Fastactivity/DetailsFilterJob.php
+++ b/CRM/Fastactivity/DetailsFilterJob.php
@@ -1,0 +1,66 @@
+<?php
+/*-------------------------------------------------------+
+| SYSTOPIA FastActivity                                  |
+| Copyright (C) 2021 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+use CRM_Fastactivity_ExtensionUtil as E;
+
+class CRM_Fastactivity_DetailsFilterJob {
+
+  /**
+   * @var int $activityId
+   */
+  protected $activityId;
+
+  /**
+   * @var string $title
+   *   The Job title.
+   */
+  public $title;
+
+  /**
+   * CRM_Fastactivity_DetailsFilterJob constructor.
+   *
+   * @param $activity_ids
+   */
+  public function __construct($activity_id) {
+    $this->activityId = $activity_id;
+    $this->title = E::ts(
+      'Filtering details for activity %1',
+      [1 => $activity_id]
+    );
+  }
+
+  /**
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function run() {
+    $activity = civicrm_api3(
+      'Activity',
+      'getsingle',
+      ['id' => $this->activityId],
+      ['return' => 'details']
+    );
+    civicrm_api3(
+      'Activity',
+      'create',
+      [
+        'id' => $this->activityId,
+        'details' => CRM_Utils_String::htmlToText($activity['details']),
+      ]
+    );
+
+    return TRUE;
+  }
+
+}

--- a/CRM/Fastactivity/Form/Settings.php
+++ b/CRM/Fastactivity/Form/Settings.php
@@ -63,17 +63,19 @@ class CRM_Fastactivity_Form_Settings extends CRM_Core_Form {
             }
             $this->add('datepicker', $name, ts($setting['description']), $setting['html_attributes'], FALSE, $setting['html_extra']);
             break;
-          case 'select2':
-            $className = E::CLASS_PREFIX . '_Form_SettingsCustom';
-            if (method_exists($className, 'addSelect2Element')) {
-              $className::addSelect2Element($this, $name, $setting);
-            }
-            break;
           case 'select':
-            $className = E::CLASS_PREFIX . '_Form_SettingsCustom';
-            if (method_exists($className, 'addSelectElement')) {
-              $className::addSelectElement($this, $name, $setting);
+            $optionValues = array();
+            if (!empty($setting['pseudoconstant']) && !empty($setting['pseudoconstant']['optionGroupName'])) {
+              $optionValues = CRM_Core_OptionGroup::values($setting['pseudoconstant']['optionGroupName'], FALSE, FALSE, FALSE, NULL, 'name');
             }
+            $this->add(
+              'select',
+              $name,
+              $setting['title'],
+              $optionValues,
+              FALSE,
+              $setting['html_attributes']
+            );
             break;
           case 'hidden':
             $hidden = TRUE;

--- a/CRM/Fastactivity/Form/Task/DetailsFilter.php
+++ b/CRM/Fastactivity/Form/Task/DetailsFilter.php
@@ -19,6 +19,8 @@ use CRM_Eventmessages_ExtensionUtil as E;
  * Filter activity detail field contents
  */
 class CRM_Fastactivity_Form_Task_DetailsFilter extends CRM_Activity_Form_Task {
+
+  const BATCH_SIZE = 25;
   
   function buildQuickForm() {
     CRM_Utils_System::setTitle(E::ts('Filter activity details'));
@@ -37,9 +39,9 @@ class CRM_Fastactivity_Form_Task_DetailsFilter extends CRM_Activity_Form_Task {
     );
 
     // Add items to the queue.
-    foreach ($this->_activityHolderIds as $activity_id) {
+    foreach (array_chunk($this->_activityHolderIds, self::BATCH_SIZE) as $activity_ids) {
       $queue->createItem(
-        new CRM_Fastactivity_DetailsFilterJob($activity_id)
+        new CRM_Fastactivity_DetailsFilterJob($activity_ids)
       );
     }
 

--- a/CRM/Fastactivity/Form/Task/DetailsFilter.php
+++ b/CRM/Fastactivity/Form/Task/DetailsFilter.php
@@ -1,0 +1,58 @@
+<?php
+/*-------------------------------------------------------+
+| SYSTOPIA FastActivity                                  |
+| Copyright (C) 2021 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+use CRM_Eventmessages_ExtensionUtil as E;
+
+/**
+ * Filter activity detail field contents
+ */
+class CRM_Fastactivity_Form_Task_DetailsFilter extends CRM_Activity_Form_Task {
+  
+  function buildQuickForm() {
+    CRM_Utils_System::setTitle(E::ts('Filter activity details'));
+    $this->addDefaultButtons(E::ts('Filter activity details'));
+  }
+
+  function postProcess() {
+    // Initialize a queue.
+    $queue = CRM_Queue_Service::singleton()->create(
+      [
+        'type' => 'Sql',
+        'name' => 'fastactivity_task_filter_activity_details_' . CRM_Core_Session::singleton(
+          )->getLoggedInContactID(),
+        'reset' => TRUE,
+      ]
+    );
+
+    // Add items to the queue.
+    foreach ($this->_activityHolderIds as $activity_id) {
+      $queue->createItem(
+        new CRM_Fastactivity_DetailsFilterJob($activity_id)
+      );
+    }
+
+    // Start a runner on the queue.
+    $runner = new CRM_Queue_Runner(
+      [
+        'title' => E::ts('Filtering activity details'),
+        'queue' => $queue,
+        'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
+        'onEndUrl' => CRM_Core_Session::singleton()->readUserContext(),
+      ]
+    );
+    $runner->runAllViaWeb();
+  }
+
+}

--- a/CRM/Fastactivity/Form/Task/DetailsFilter.php
+++ b/CRM/Fastactivity/Form/Task/DetailsFilter.php
@@ -13,7 +13,7 @@
 | written permission from the original author(s).        |
 +--------------------------------------------------------*/
 
-use CRM_Eventmessages_ExtensionUtil as E;
+use CRM_Fastactivity_ExtensionUtil as E;
 
 /**
  * Filter activity detail field contents

--- a/fastactivity.php
+++ b/fastactivity.php
@@ -271,3 +271,20 @@ function fastactivity_civicrm_pre($op, $objectName, $id, &$params) {
     }
   }
 }
+
+/**
+ * Implements hook_civicrm_searchTasks().
+ *
+ * @url https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_searchTasks/
+ */
+function fastactivity_civicrm_searchTasks($objectType, &$tasks)
+{
+  // add "Filter activity details" task to activity search result actions.
+  if ($objectType == 'activity') {
+    $tasks[] = [
+      'title' => E::ts('Filter activity details'),
+      'class' => 'CRM_Fastactivity_Form_Task_DetailsFilter',
+      'result' => false,
+    ];
+  }
+}

--- a/fastactivity.php
+++ b/fastactivity.php
@@ -255,3 +255,19 @@ function fastactivity_civicrm_links($op, $objectName, $objectId, &$links, &$mask
     }
   }
 }
+
+/**
+ * Implements hook_civicrm_pre().
+ *
+ * @url https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_pre/
+ */
+function fastactivity_civicrm_pre($op, $objectName, $id, &$params) {
+  if ($objectName == 'Activity' && $op == 'create') {
+    // Run details field contents for activities of configured types through a
+    // text filter for reducing the record size.
+    $activity_type_ids = Civi::settings()->get('fastactivity_filter_details_activity_types') ?: [];
+    if (in_array($params['activity_type_id'], $activity_type_ids)) {
+      $params['details'] = CRM_Utils_String::htmlToText($params['details']);
+    }
+  }
+}

--- a/settings/fastactivity.setting.php
+++ b/settings/fastactivity.setting.php
@@ -135,4 +135,22 @@ return array(
     'description' => 'Exclude Case Activities from the activity tab',
     'html_attributes' => array(),
   ),
+  'fastactivity_filter_details_activity_types' => array(
+    'group_name' => 'FastActivity Settings',
+    'group' => 'fastactivity',
+    'name' => 'fastactivity_filter_details_activity_types',
+    'type' => 'Integer',
+    'html_type' => 'select',
+    'pseudoconstant' => ['optionGroupName' => 'activity_type'],
+    'default' => NULL,
+    'add' => '5.0',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'title' => 'Activity types to filter details for',
+    'description' => 'Activity types for which to run the details field contents through a text filter for reducing storage size.',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+      'multiple' => 1,
+    ],
+  ),
 );

--- a/templates/CRM/Fastactivity/Form/Settings.hlp
+++ b/templates/CRM/Fastactivity/Form/Settings.hlp
@@ -38,6 +38,6 @@
 <p>{ts}Activity types for which to run the <em>Details</em> field contents through a text filter for reducing storage size.{/ts}</p>
 <p>{ts}This will filter the <em>Details</em> field contents of activities with the selected types prior to saving them, removing all HTML tags (including images), resulting in a plain text version of the field.{/ts}</p>
 <p>{ts}This is especially useful for activities created for mailings or letters, where the complete mailing or letter template is being fed into the activity but cannot be rendered correctly anyway when viewing the activity, so selecting those activity types can help keep the activity database table small.{/ts}</p>
-<p>{ts}Keep in mind, though, that there is no way to restore HTML contents once it has been run through the plain text filter.{/ts}</p>
+<p>{ts}Keep in mind, though, that there is no way to restore HTML contents once it has been run through the plain text filter. You will also not be able to regenerate the document from the filtered activity details content.{/ts}</p>
 <p>{ts}There is also an activity search result action for filtering <em>Details</em> field contents of existing activites.{/ts}</p>
 {/htxt}

--- a/templates/CRM/Fastactivity/Form/Settings.hlp
+++ b/templates/CRM/Fastactivity/Form/Settings.hlp
@@ -34,3 +34,6 @@
 {htxt id='tab_exclude_case_activities'}
 {ts}Exclude Case Activities from the activities tab (this is the default in the standard activities tab){/ts}
 {/htxt}
+{htxt id='filter_details_activity_types'}
+{ts}Activity types for which to run the details field contents through a text filter for reducing storage size.{/ts}
+{/htxt}

--- a/templates/CRM/Fastactivity/Form/Settings.hlp
+++ b/templates/CRM/Fastactivity/Form/Settings.hlp
@@ -35,5 +35,9 @@
 {ts}Exclude Case Activities from the activities tab (this is the default in the standard activities tab){/ts}
 {/htxt}
 {htxt id='filter_details_activity_types'}
-{ts}Activity types for which to run the details field contents through a text filter for reducing storage size.{/ts}
+<p>{ts}Activity types for which to run the <em>Details</em> field contents through a text filter for reducing storage size.{/ts}</p>
+<p>{ts}This will filter the <em>Details</em> field contents of activities with the selected types prior to saving them, removing all HTML tags (including images), resulting in a plain text version of the field.{/ts}</p>
+<p>{ts}This is especially useful for activities created for mailings or letters, where the complete mailing or letter template is being fed into the activity but cannot be rendered correctly anyway when viewing the activity, so selecting those activity types can help keep the activity database table small.{/ts}</p>
+<p>{ts}Keep in mind, though, that there is no way to restore HTML contents once it has been run through the plain text filter.{/ts}</p>
+<p>{ts}There is also an activity search result action for filtering <em>Details</em> field contents of existing activites.{/ts}</p>
 {/htxt}

--- a/templates/CRM/Fastactivity/Form/Settings.tpl
+++ b/templates/CRM/Fastactivity/Form/Settings.tpl
@@ -30,7 +30,7 @@
 <div>
   {foreach from=$elementGroup.elementNames item=elementName}
   <div class="crm-section">
-    <div class="label">{$form.$elementName.label}</div>
+    <div class="label">{$form.$elementName.label} {help id=$elementName file="CRM/Fastactivity/Form/Settings.hlp"}</div>
     <div class="content">{$form.$elementName.html}</div>
     <div class="clear"></div>
   </div>

--- a/templates/CRM/Fastactivity/Form/Task/DetailsFilter.tpl
+++ b/templates/CRM/Fastactivity/Form/Task/DetailsFilter.tpl
@@ -13,7 +13,16 @@
 +-------------------------------------------------------*}
 
 {crmScope extensionKey='de.systopia.fastactivity'}
-  <div class="crm-submit-buttons">
-      {include file="CRM/common/formButtons.tpl" location="bottom"}
+  <div class="help">
+    <p>{ts}This task will filter the <em>Details</em>
+        field contents of selected activities, removing all HTML tags,
+        resulting an a plain text version of the field. This action cannot be
+        undone.{/ts}</p>
+  </div>
+
+  <div class="crm-form-block">
+    <div class="crm-submit-buttons">
+        {include file="CRM/common/formButtons.tpl" location="bottom"}
+    </div>
   </div>
 {/crmScope}

--- a/templates/CRM/Fastactivity/Form/Task/DetailsFilter.tpl
+++ b/templates/CRM/Fastactivity/Form/Task/DetailsFilter.tpl
@@ -1,0 +1,19 @@
+{*-------------------------------------------------------+
+| SYSTOPIA FastActivity                                  |
+| Copyright (C) 2021 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{crmScope extensionKey='de.systopia.fastactivity'}
+  <div class="crm-submit-buttons">
+      {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+{/crmScope}


### PR DESCRIPTION
This adds a configuration option for selecting activity types for which to filter details when saving. This might be useful for e.g. "Print/Merge Document" activities for reducing stoarge size, since the complete template contents is being saved to the activity details field for those activities, if regenerating documents from the activity (i.e. creating a copy) is not necessary.