### PR TITLE
Fix for issue #50: fixed error when activity is editted

### DIFF
--- a/templates/CRM/Fastactivity/Form/Add.tpl
+++ b/templates/CRM/Fastactivity/Form/Add.tpl
@@ -289,6 +289,10 @@
           previewDialog();
         }
       }
+      else {
+        // Avoid jquery validation on required fields if they are visible
+        $('#recurring-entity-block :input').removeClass('required');
+      }
     });
   });
 </script>


### PR DESCRIPTION
This PR fixes issue #50.

**How to reproduce**

1. Add a new activity of type meeting and status scheduled
2. Edit this activity through the fast ativity tab and set status to completed
3. Press Save

**What to expect**

The activity is set the completed and saved succesfully

**Actual result**

An error is shown: 'Field is required'. 