### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/systopia/de.systopia.fastactivity/issues</url>
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>1.5.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>Developed by Matthew Wire and SYSTOPIA</comments>
   <civix>

--- a/templates/CRM/Fastactivity/Form/Add.tpl
+++ b/templates/CRM/Fastactivity/Form/Add.tpl
@@ -72,7 +72,7 @@
       <td>
         {$form.assignee_contact_id.html}
         {if !$activityTargetCount}
-          <a href="#" class="crm-hover-button" id="swap_target_assignee" title="{ts}Swap Target and Assignee Contacts{/ts}" style="position:relative; bottom: 1em;">
+          <a href="#" class="crm-hover-button" id="swap_target_assignee" title="{ts escape='htmlattribute'}Swap Target and Assignee Contacts{/ts}" style="position:relative; bottom: 1em;">
             <span class="icon ui-icon-shuffle"></span>
           </a>
         {/if}


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.