### PR TITLE
CRM_Fastactivity_Form_Add: Fix `add()` method call for field `followup_date`

### DIFF
--- a/CRM/Fastactivity/Form/Add.php
+++ b/CRM/Fastactivity/Form/Add.php
@@ -403,7 +403,7 @@ class CRM_Fastactivity_Form_Add extends CRM_Fastactivity_Form_Base {
     $this->add('datepicker','activity_date_time', ts('Date'), array('formatType' => 'activityDateTime'), TRUE);
 
     //add followup date
-    $this->add('datepicker', 'followup_date', ts('in'), FALSE, array('formatType' => 'activityDateTime'));
+    $this->add('datepicker', 'followup_date', ts('in'), array('formatType' => 'activityDateTime'));
 
     // Only admins can change the activity source contact
     if (!CRM_Core_Permission::check('administer CiviCRM')) {


### PR DESCRIPTION
systopia-reference: 30389