### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Fastactivity/BAO/Activity.php
+++ b/CRM/Fastactivity/BAO/Activity.php
@@ -228,16 +228,16 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
    */
   public static function whereClause(&$params, $sortBy = TRUE, $excludeHidden = TRUE) {
     // activity type ID clause
-    $activity_type_id = CRM_Utils_Array::value('activity_type_id', $params);
-    $activity_type_exclude_id = CRM_Utils_Array::value('activity_type_exclude_id', $params);
-    $activity_date_relative = CRM_Utils_Array::value('activity_date_relative', $params);
-    $activity_date_low = CRM_Utils_Array::value('activity_date_low', $params);
-    $activity_date_high = CRM_Utils_Array::value('activity_date_high', $params);
-    $activity_status_id = CRM_Utils_Array::value('activity_status_id', $params);
+    $activity_type_id = $params['activity_type_id'] ?? NULL;
+    $activity_type_exclude_id = $params['activity_type_exclude_id'] ?? NULL;
+    $activity_date_relative = $params['activity_date_relative'] ?? NULL;
+    $activity_date_low = $params['activity_date_low'] ?? NULL;
+    $activity_date_high = $params['activity_date_high'] ?? NULL;
+    $activity_status_id = $params['activity_status_id'] ?? NULL;
     $excludeCaseActivities = CRM_Utils_Array::value('excludeCaseActivities', $params, TRUE);
 
     // contact_id
-    $contact_id = CRM_Utils_Array::value('contact_id', $params);
+    $contact_id = $params['contact_id'] ?? NULL;
     if ($contact_id) {
       $clauses[] = "acon.contact_id = %1";
       $params[1] = array($contact_id, 'Integer');
@@ -284,7 +284,7 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
       // optionalCols not set when triggered from fastactivity_civicrm_tabs
       if ($params['optionalCols']['campaign_title']) {
         // campaign ID clause. Match on campaign and all sub-campaigns.
-        $activity_campaign_id = CRM_Utils_Array::value('activity_campaign_id', $params);
+        $activity_campaign_id = $params['activity_campaign_id'] ?? NULL;
         if (!empty($activity_campaign_id)) {
           // Make campaign IDs into array
           $searchCampaignIds = explode(',', $activity_campaign_id);
@@ -474,10 +474,10 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
     // format the params
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
     $params['rowCount'] = $params['rp'];
-    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
-    $params['outerSort'] = CRM_Utils_Array::value('outerSortBy', $params);
+    $params['sort'] = $params['sortBy'] ?? NULL;
+    $params['outerSort'] = $params['outerSortBy'] ?? NULL;
     $params['caseId'] = NULL;
-    $context = CRM_Utils_Array::value('context', $params);
+    $context = $params['context'] ?? NULL;
 
     // get contact activities
     $activities = CRM_Fastactivity_BAO_Activity::getContactActivities($params);
@@ -548,8 +548,8 @@ class CRM_Fastactivity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
         $actionLinks = self::actionLinks(
           CRM_Utils_Array::value('activity_type_id', $values),
-          CRM_Utils_Array::value('activity_id', $values),
-          CRM_Utils_Array::value('contact_id', $params)
+          $values['activity_id'] ?? NULL,
+          $params['contact_id'] ?? NULL
         );
 
         $actionMask = array_sum(array_keys($actionLinks)) & $mask;

--- a/CRM/Fastactivity/Form/Report/FastActivity.php
+++ b/CRM/Fastactivity/Form/Report/FastActivity.php
@@ -235,20 +235,20 @@ class CRM_Fastactivity_Form_Report_FastActivity extends CRM_Report_Form {
       $this->_columnHeaders["contact_source_id"]['no_display'] = TRUE;
       return "fa_source.contact_id as contact_source_id";
     } elseif ($fieldName == 'target_sort_name') {
-      $this->_columnHeaders['target_sort_name']['title']       = CRM_Utils_Array::value('title', $field);
-      $this->_columnHeaders['target_sort_name']['type']        = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['target_sort_name']['title']       = $field['title'] ?? NULL;
+      $this->_columnHeaders['target_sort_name']['type']        = $field['type'] ?? NULL;
       $this->_columnHeaders['target_contact_id']['no_display'] = TRUE;
       return "GROUP_CONCAT(DISTINCT fa_target_contact.sort_name SEPARATOR ';') AS target_sort_name, GROUP_CONCAT(DISTINCT fa_target_contact.id SEPARATOR ';') AS target_contact_id";
 
     } elseif ($fieldName == 'assignee_sort_name') {
-      $this->_columnHeaders['assignee_sort_name']['title'] = CRM_Utils_Array::value('title', $field);
-      $this->_columnHeaders['assignee_sort_name']['type'] = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['assignee_sort_name']['title'] = $field['title'] ?? NULL;
+      $this->_columnHeaders['assignee_sort_name']['type'] = $field['type'] ?? NULL;
       $this->_columnHeaders['assignee_contact_id']['no_display'] = TRUE;
       return "GROUP_CONCAT(DISTINCT fa_assignee_contact.sort_name SEPARATOR ';') AS assignee_sort_name, GROUP_CONCAT(DISTINCT fa_assignee_contact.id SEPARATOR ';') AS assignee_contact_id";
 
     } elseif ($fieldName == 'campaign') {
-      $this->_columnHeaders['campaign']['title'] = CRM_Utils_Array::value('title', $field);
-      //$this->_columnHeaders['campaign']['type'] = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders['campaign']['title'] = $field['title'] ?? NULL;
+      //$this->_columnHeaders['campaign']['type'] = $field['type'] ?? NULL;
       return "campaign.title AS campaign";
 
     } elseif ($fieldName == 'actions') {


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.