### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Fastactivity/DetailsFilterJob.php
+++ b/CRM/Fastactivity/DetailsFilterJob.php
@@ -42,7 +42,7 @@ class CRM_Fastactivity_DetailsFilterJob {
   }
 
   /**
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function run() {
     foreach ($this->activityIds as $activityId) {


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.